### PR TITLE
#70: PowerShell main process send KeyStroke on child process, added JNetPSCmdlet to consolidate API override on not externalizable cmdlets

### DIFF
--- a/src/net/JNetPSCore/Cmdlet/NewObjectCmdletCommandBase.cs
+++ b/src/net/JNetPSCore/Cmdlet/NewObjectCmdletCommandBase.cs
@@ -22,7 +22,7 @@ using System.Management.Automation;
 
 namespace MASES.JNetPSCore.Cmdlet
 {
-    public abstract class NewObjectCmdletCommandBase<TCmdlet, TCore> : JNetPSExternalizableCmdlet<TCmdlet>
+    public abstract class NewObjectCmdletCommandBase<TCmdlet, TCore> : JNetPSCmdlet<TCore>
         where TCmdlet : NewObjectCmdletCommandBase<TCmdlet, TCore>
         where TCore : JNetCore<TCore>
     {
@@ -41,12 +41,6 @@ namespace MASES.JNetPSCore.Cmdlet
         // This method will be called for each input received from the pipeline to this cmdlet; if no input is received, this method is not called
         protected override void ProcessCommand()
         {
-            if (!JNetPSHelper<TCore>.InstanceCreated)
-            {
-                WriteWarning("Engine was not started, cannot execute the command");
-                return;
-            }
-
             object[] args = Arguments;
             if (Arguments != null)
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Some updates to better manage inputs sent to child processes

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closed #70 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The inputs was not received from child PowerShell process

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
