### PR TITLE
#142: update Javadoc association when multiple JARs set in command line

### DIFF
--- a/src/net/JNetReflector/InternalExtensions.cs
+++ b/src/net/JNetReflector/InternalExtensions.cs
@@ -30,6 +30,9 @@ namespace MASES.JNetReflector
 {
     static class JNetReflectorExtensions
     {
+        static string _CurrentJavadocBaseUrl;
+        static int _CurrentJavadocVersion;
+
         static Java.Lang.ClassLoader _loader;
         static Java.Lang.ClassLoader SystemClassLoader
         {
@@ -39,6 +42,16 @@ namespace MASES.JNetReflector
                 return _loader;
             }
         }
+
+        #region General info
+
+        public static void SetJavaDocInfo(string currentJavadocBaseUrl, int currentJavadocVersion)
+        {
+            _CurrentJavadocBaseUrl = currentJavadocBaseUrl;
+            _CurrentJavadocVersion = currentJavadocVersion;
+        }
+
+        #endregion
 
         #region string extension
 
@@ -1261,13 +1274,13 @@ namespace MASES.JNetReflector
         {
             if (entry == null) throw new ArgumentNullException(nameof(entry));
 
-            var newURl = JNetReflectorCore.OriginJavadocUrl;
+            var newURl = _CurrentJavadocBaseUrl;
             if (newURl != null)
             {
                 if (!newURl.EndsWith("/"))
                     newURl += '/';
 
-                if (JNetReflectorCore.JavadocVersion > 9)
+                if (_CurrentJavadocVersion > 9)
                 {
                     var module = entry.Module;
 #if USE_MODULEINFO
@@ -1300,7 +1313,7 @@ namespace MASES.JNetReflector
 
         public static string JavadocHrefUrl(this Class entry, bool camel)
         {
-            return string.Format(AllPackageClasses.DocTemplate, JavadocUrl(entry, camel).Replace("<", "%3C").Replace(">", "%3E"));
+            return string.Format(AllPackageClasses.DocTemplate(_CurrentJavadocBaseUrl), JavadocUrl(entry, camel).Replace("<", "%3C").Replace(">", "%3E"));
         }
 
         #endregion
@@ -1361,7 +1374,7 @@ namespace MASES.JNetReflector
         public static string JavadocUrl(this Constructor entry, bool camel)
         {
             var newURl = entry.DeclaringClass.JavadocUrl(camel);
-            if (JNetReflectorCore.OriginJavadocUrl != null)
+            if (_CurrentJavadocBaseUrl != null)
             {
                 var genString = entry.GenericString;
                 genString = entry.Name + "(";
@@ -1376,7 +1389,7 @@ namespace MASES.JNetReflector
                 genString += ")";
 
                 if (genString.Contains("throws")) genString = genString.Substring(0, genString.IndexOf("throws") - 1);
-                if (JNetReflectorCore.JavadocVersion > 9)
+                if (_CurrentJavadocVersion > 9)
                 {
                     genString = genString.StartsWith(entry.Name) ? genString.Substring(entry.Name.Length) : genString.Substring(genString.IndexOf(entry.Name) + entry.Name.Length);
                     genString = "<init>" + genString;
@@ -1386,7 +1399,7 @@ namespace MASES.JNetReflector
                     genString = genString.Substring(genString.IndexOf(entry.Name));
                 }
 
-                if (JNetReflectorCore.JavadocVersion < 7)
+                if (_CurrentJavadocVersion < 7)
                 {
                     genString = genString.Replace(",", ", ");
                 }
@@ -1400,7 +1413,7 @@ namespace MASES.JNetReflector
 
         public static string JavadocHrefUrl(this Constructor entry, bool camel)
         {
-            return string.Format(AllPackageClasses.DocTemplate, JavadocUrl(entry, camel).Replace("<", "%3C").Replace(">", "%3E"));
+            return string.Format(AllPackageClasses.DocTemplate(_CurrentJavadocBaseUrl), JavadocUrl(entry, camel).Replace("<", "%3C").Replace(">", "%3E"));
         }
 
         #endregion
@@ -1653,7 +1666,7 @@ namespace MASES.JNetReflector
         public static string JavadocUrl(this Method entry, bool camel)
         {
             var newURl = entry.DeclaringClass.JavadocUrl(camel);
-            if (JNetReflectorCore.OriginJavadocUrl != null)
+            if (_CurrentJavadocBaseUrl != null)
             {
                 var genString = entry.GenericString;
                 genString = genString.Substring(genString.IndexOf(entry.Name));
@@ -1669,11 +1682,11 @@ namespace MASES.JNetReflector
                 genString += ")";
 
                 if (genString.Contains("throws")) genString = genString.Substring(0, genString.IndexOf("throws") - 1);
-                if (JNetReflectorCore.JavadocVersion < 7)
+                if (_CurrentJavadocVersion < 7)
                 {
                     genString = genString.Replace(",", ", ");
                 }
-                else if (JNetReflectorCore.JavadocVersion > 7 && JNetReflectorCore.JavadocVersion < 10)
+                else if (_CurrentJavadocVersion > 7 && _CurrentJavadocVersion < 10)
                 {
                     genString = genString.Replace(",", "-").Replace('(', '-').Replace(')', '-');
                 }
@@ -1687,7 +1700,7 @@ namespace MASES.JNetReflector
 
         public static string JavadocHrefUrl(this Method entry, bool camel)
         {
-            return string.Format(AllPackageClasses.DocTemplate, JavadocUrl(entry, camel).Replace("<", "%3C").Replace(">", "%3E"));
+            return string.Format(AllPackageClasses.DocTemplate(_CurrentJavadocBaseUrl), JavadocUrl(entry, camel).Replace("<", "%3C").Replace(">", "%3E"));
         }
 
         #endregion
@@ -1771,7 +1784,7 @@ namespace MASES.JNetReflector
         public static string JavadocUrl(this Field entry, bool camel)
         {
             var newURl = entry.DeclaringClass.JavadocUrl(camel);
-            if (JNetReflectorCore.OriginJavadocUrl != null)
+            if (_CurrentJavadocBaseUrl != null)
             {
                 var genString = entry.Name;
                 newURl += "#" + genString;
@@ -1783,7 +1796,7 @@ namespace MASES.JNetReflector
 
         public static string JavadocHrefUrl(this Field entry, bool camel)
         {
-            return string.Format(AllPackageClasses.DocTemplate, JavadocUrl(entry, camel).Replace("<", "%3C").Replace(">", "%3E"));
+            return string.Format(AllPackageClasses.DocTemplate(_CurrentJavadocBaseUrl), JavadocUrl(entry, camel).Replace("<", "%3C").Replace(">", "%3E"));
         }
 
         #endregion

--- a/src/net/JNetReflector/InternalMethods.cs
+++ b/src/net/JNetReflector/InternalMethods.cs
@@ -131,8 +131,7 @@ namespace MASES.JNetReflector
                 var jClass = item.JVMClass(true);
                 if (jClass != null) resultingArguments.AddItem(jClass);
             }
-            JavadocBaseUrl = JNetReflectorCore.OriginJavadocUrl;
-            JavadocVersion = JNetReflectorCore.JavadocVersion;
+            JNetReflectorExtensions.SetJavaDocInfo(JNetReflectorCore.OriginJavadocUrl, JNetReflectorCore.JavadocVersion);
             JarOrModuleName = "CustomSelection";
             resultingArguments.AnalyzeItems();
         }
@@ -183,8 +182,7 @@ namespace MASES.JNetReflector
                 }
 
                 ReportTrace(ReflectionTraceLevel.Info, "Starting analysis for {0} entries", resultingArguments.Count);
-                JavadocBaseUrl = javadocUrl;
-                JavadocVersion = javadocVersion;
+                JNetReflectorExtensions.SetJavaDocInfo(javadocUrl, javadocVersion);
                 JarOrModuleName = Path.GetFileName(pathToJar);
                 resultingArguments.AnalyzeItems();
             }
@@ -210,15 +208,13 @@ namespace MASES.JNetReflector
             }
 
             ReportTrace(ReflectionTraceLevel.Info, "Starting analysis for {0} entries", data.Count);
-            JavadocBaseUrl = JNetReflectorCore.OriginJavadocUrl;
-            JavadocVersion = JNetReflectorCore.JavadocVersion;
+            JNetReflectorExtensions.SetJavaDocInfo(JNetReflectorCore.OriginJavadocUrl, JNetReflectorCore.JavadocVersion);
             JarOrModuleName = ns;
             data.AnalyzeItems();
         }
 
-        static string JavadocBaseUrl { get; set; }
-        static int JavadocVersion { get; set; }
         static string JarOrModuleName { get; set; }
+
         static CancellationTokenSource CancellationTokenSource { get; set; }
 
         static void AnalyzeItems(this IDictionary<string, IDictionary<string, IDictionary<string, Class>>> items)

--- a/src/net/JNetReflector/JNetReflector.csproj
+++ b/src/net/JNetReflector/JNetReflector.csproj
@@ -141,7 +141,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MASES.CLIParser" Version="3.1.2" />
-	<PackageReference Include="MASES.JCOBridge" Version="2.5.4">
+	<PackageReference Include="MASES.JCOBridge" Version="2.5.5">
 		<IncludeAssets>All</IncludeAssets>
 		<PrivateAssets>None</PrivateAssets>
 	</PackageReference>

--- a/src/net/JNetReflector/Templates/Templates.cs
+++ b/src/net/JNetReflector/Templates/Templates.cs
@@ -99,7 +99,7 @@ namespace MASES.JNetReflector.Templates
         public const string NAMESPACE = "ALLPACKAGE_NAMESPACE_PLACEHOLDER";
         public const string CLASSES = "// ALLPACKAGE_CLASSES_PLACEHOLDER";
 
-        public static string DocTemplate => JNetReflectorCore.OriginJavadocUrl != null ? HREF_URL : CREF_URL;
+        public static string DocTemplate(string jdocUrl) => jdocUrl != null ? HREF_URL : CREF_URL;
 
         const string CREF_URL = "<see cref=\"{0}\"/>";
         const string HREF_URL = "<see href=\"{0}\"/>";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When multiple JARs are set in command-line, each one can have its own JavaDoc URL and version: the tool is able to associate JavaDoc to each JAR elaborated

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fix #142 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
