### PR TITLE
Update JAR management reporting classes not identified

### DIFF
--- a/src/net/JNetReflector/InternalExtensions.cs
+++ b/src/net/JNetReflector/InternalExtensions.cs
@@ -31,6 +31,7 @@ using System.Reflection.Emit;
 using System.Text.RegularExpressions;
 using Org.Mases.Jnet;
 using System.Diagnostics;
+using MASES.JCOBridge.C2JBridge;
 
 namespace MASES.JNetReflector
 {
@@ -437,9 +438,9 @@ namespace MASES.JNetReflector
             {
                 return Class.ForName(cName, true, Class.SystemClassLoader);
             }
-            catch (ClassNotFoundException cnfe)
+            catch (JVMBridgeException cnfe)
             {
-                ReflectionUtils.ReportTrace(ReflectionUtils.ReflectionTraceLevel.Error, $"JVMClass: ClassNotFoundException loading {cName} with error: {cnfe.Message}");
+                ReflectionUtils.ReportTrace(ReflectionUtils.ReflectionTraceLevel.Error, $"JVMClass: {cnfe.GetType().Name} loading {cName} with message: {cnfe.Message}");
                 return null;
             }
             catch

--- a/src/net/JNetReflector/JNetReflector.csproj
+++ b/src/net/JNetReflector/JNetReflector.csproj
@@ -54,11 +54,15 @@
   <ItemGroup>
     <Compile Include="..\JNet\Developed\Java\Lang\Annotation\Annotation.cs" Link="Java\Lang\Annotation\Annotation.cs" />
     <Compile Include="..\JNet\Developed\Java\Lang\Class.cs" Link="Java\Lang\Class.cs" />
+    <Compile Include="..\JNet\Developed\Java\Lang\ClassFormatError.cs" Link="Java\Lang\ClassFormatError.cs" />
     <Compile Include="..\JNet\Developed\Java\Lang\ClassLoader.cs" Link="Java\Lang\ClassLoader.cs" />
     <Compile Include="..\JNet\Developed\Java\Lang\ClassNotFoundException.cs" Link="Java\Lang\ClassNotFoundException.cs" />
+    <Compile Include="..\JNet\Developed\Java\Lang\Error.cs" Link="Java\Lang\Error.cs" />
     <Compile Include="..\JNet\Developed\Java\Lang\Exception.cs" Link="Java\Lang\Exception.cs" />
     <Compile Include="..\JNet\Developed\Java\Lang\Iterable.cs" Link="Java\Lang\Iterable.cs" />
+    <Compile Include="..\JNet\Developed\Java\Lang\LinkageError.cs" Link="Java\Lang\LinkageError.cs" />
     <Compile Include="..\JNet\Developed\Java\Lang\Module.cs" Link="Java\Lang\Module.cs" />
+    <Compile Include="..\JNet\Developed\Java\Lang\NoClassDefFoundError.cs" Link="Java\Lang\NoClassDefFoundError.cs" />
     <Compile Include="..\JNet\Developed\Java\Lang\NoSuchMethodException.cs" Link="Java\Lang\NoSuchMethodException.cs" />
     <Compile Include="..\JNet\Developed\Java\Lang\Object.cs" Link="Java\Lang\Object.cs" />
     <Compile Include="..\JNet\Developed\Java\Lang\Package.cs" Link="Java\Lang\Package.cs" />
@@ -78,8 +82,11 @@
     <Compile Include="..\JNet\Developed\Java\Lang\Reflect\Type.cs" Link="Java\Lang\Reflect\Type.cs" />
     <Compile Include="..\JNet\Developed\Java\Lang\Reflect\TypeVariable.cs" Link="Java\Lang\Reflect\TypeVariable.cs" />
     <Compile Include="..\JNet\Developed\Java\Lang\Reflect\WildcardType.cs" Link="Java\Lang\Reflect\WildcardType.cs" />
+    <Compile Include="..\JNet\Developed\Java\Lang\RuntimeException.cs" Link="Java\Lang\RuntimeException.cs" />
     <Compile Include="..\JNet\Developed\Java\Lang\SecurityManager.cs" Link="Java\Lang\SecurityManager.cs" />
     <Compile Include="..\JNet\Developed\Java\Lang\Throwable.cs" Link="Java\Lang\Throwable.cs" />
+    <Compile Include="..\JNet\Developed\Java\Lang\UnsupportedClassVersionError.cs" Link="Java\Lang\UnsupportedClassVersionError.cs" />
+    <Compile Include="..\JNet\Developed\Java\Lang\UnsupportedOperationException.cs" Link="Java\Lang\UnsupportedOperationException.cs" />
     <Compile Include="..\JNet\Developed\Java\Util\Collection.cs" Link="Java\Util\Collection.cs" />
     <Compile Include="..\JNet\Developed\Java\Util\Iterator.cs" Link="Java\Util\Iterator.cs" />
     <Compile Include="..\JNet\JNetCoreBase.cs" Link="JNetCoreBase.cs" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

It is possible that the JVM used from JNetReflector does not support some classes, e.g. `java.util.SequencedMap` (available from JDK 21), or there is a missing dependency in the classpath: the tool now reports classes found in the JAR but not loaded.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
