### PR TITLE
JNet is able to manage environment variables with the pattern $(ENV_VAR)

### DIFF
--- a/src/net/JNetReflector/JNetReflectorCore.cs
+++ b/src/net/JNetReflector/JNetReflectorCore.cs
@@ -69,11 +69,11 @@ namespace MASES.JNetReflector
             {
                 public JVMOption(string optionName, string optionValue)
                 {
-                    OptionName = optionName;
-                    OptionValue = optionValue;
+                    Name = optionName;
+                    Value = optionValue;
                 }
-                public string OptionName { get; set; }
-                public string OptionValue { get; set; }
+                public string Name { get; set; }
+                public string Value { get; set; }
             }
 
             public IEnumerable<JVMOption> JVMOptions { get; set; }
@@ -844,7 +844,7 @@ namespace MASES.JNetReflector
                     Dictionary<string, string> dict = new();
                     foreach (var item in _ConfigurationFromFile.JVMOptions)
                     {
-                        dict.Add(item.OptionName, item.OptionValue);
+                        dict.Add(item.Name, item.Value);
                     }
                     return dict;
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
JNet is able to manage environment variables in JVM options with the pattern $(ENV_VAR)

JVMOptions of JNetReflector configuration updates and simplify parameter names:
- OptionName -> Name
- OptionValue -> Value

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
closed #600
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
