### PR TITLE
Refactor TestAsyncOperation to accept exception flag

### DIFF
--- a/tests/net/JNetTest/Program.cs
+++ b/tests/net/JNetTest/Program.cs
@@ -61,7 +61,18 @@ namespace MASES.JNetTest
 
             TestAsyncOperation(false).Wait();
 
-            TestAsyncOperation(true).Wait();
+            try
+            {
+                TestAsyncOperation(true).Wait();
+            }
+            catch (System.AggregateException ae)
+            {
+                if (ae.InnerException is not UnsupportedOperationException)
+                {
+                    System.Console.WriteLine($"Not expected exception: {ae.InnerException.GetType()}");
+                    throw;
+                }
+            }
         }
 
         static void Initialize()
@@ -282,21 +293,11 @@ namespace MASES.JNetTest
             var jClass = JNetTestCore.GlobalInstance.JVM.New("org.mases.jnet.TestFuture") as IJavaObject;
 
             CompletableFuture<String> completableFuture = jClass.Invoke<CompletableFuture<String>>(withEx ? "withException" : "withComplete");
-            try
+
+            String result = await completableFuture.GetAsync();
+            if (result != "Hello")
             {
-                String result = await completableFuture.GetAsync();
-                if (result != "Hello")
-                {
-                    System.Console.WriteLine($"Failed to compare: {result}");
-                }
-            }
-            catch (System.AggregateException ae)
-            {
-                if (ae.InnerException is not UnsupportedOperationException)
-                {
-                    System.Console.WriteLine($"Not expected exception: {ae.InnerException.GetType()}");
-                    throw;
-                }
+                System.Console.WriteLine($"Failed to compare: {result}");
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
TestAsyncOperation now takes a boolean parameter to control whether to test normal completion or exception handling. The main method calls TestAsyncOperation for both cases, improving test coverage for CompletableFuture with and without exceptions.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fix #614
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
