### PR TITLE
Fix indentation and remove PackageType from JNetCLICore

### DIFF
--- a/src/net/JNetCLI/JNetCLI.nuspec
+++ b/src/net/JNetCLI/JNetCLI.nuspec
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
-  <metadata>
-    <id>MASES.JNetCLI</id>
-    <version>2.5.13</version>
-    <title>JNetCLI - JNet command line interface</title>
-    <authors>MASES s.r.l.</authors>
-    <owners>MASES s.r.l.</owners>
-    <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <projectUrl>https://github.com/masesgroup/JNet/</projectUrl>
-    <repository type="git" url="https://github.com/masesgroup/JNet/" />
-    <description>JNetCLI - CLI interface of JNet</description>
-    <releaseNotes>https://github.com/masesgroup/JNet/releases</releaseNotes>
-    <copyright>Copyright ©  MASES s.r.l. 2025</copyright>
-    <license type="file">LICENSE</license>
-    <icon>JCOB128x128.png</icon>
-    <tags>jnet cli dotnet clr netcore net8</tags>
-    <packageTypes>
-    <packageType name="DotnetTool" />
-    </packageTypes>
-    <readme>usageCLI.md</readme>
-  </metadata>
+	<metadata>
+		<id>MASES.JNetCLI</id>
+		<version>2.5.13</version>
+		<title>JNetCLI - JNet command line interface</title>
+		<authors>MASES s.r.l.</authors>
+		<owners>MASES s.r.l.</owners>
+		<requireLicenseAcceptance>true</requireLicenseAcceptance>
+		<projectUrl>https://github.com/masesgroup/JNet/</projectUrl>
+		<repository type="git" url="https://github.com/masesgroup/JNet/" />
+		<description>JNetCLI - CLI interface of JNet</description>
+		<releaseNotes>https://github.com/masesgroup/JNet/releases</releaseNotes>
+		<copyright>Copyright ©  MASES s.r.l. 2025</copyright>
+		<license type="file">LICENSE</license>
+		<icon>JCOB128x128.png</icon>
+		<tags>jnet cli dotnet clr netcore net8</tags>
+		<packageTypes>
+			<packageType name="DotnetTool" />
+		</packageTypes>
+		<readme>usageCLI.md</readme>
+	</metadata>
 	<files>
 		<file src="..\..\..\LICENSE" target="LICENSE" />
 		<file src="..\Common\JCOB128x128.png" target="" />

--- a/src/net/JNetCLICore/JNetCLICore.csproj
+++ b/src/net/JNetCLICore/JNetCLICore.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<Import Project="..\Common\Common.props" />
 	<PropertyGroup>
-		<PackageType>DotnetTool</PackageType>
 		<AssemblyName>MASES.JNetCLICore</AssemblyName>
 		<RootNamespace>MASES.JNet.CLI</RootNamespace>
 		<Title>JNetCLI - JNet (.NET suite for Java™/JVM™) command line base library</Title>

--- a/src/net/JNetReflector/JNetReflector.nuspec
+++ b/src/net/JNetReflector/JNetReflector.nuspec
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
-  <metadata>
-    <id>MASES.JNetReflector</id>
-    <version>2.5.13</version>
-    <title>JNetReflector - JNet class reflection utility command line interface</title>
-    <authors>MASES s.r.l.</authors>
-    <owners>MASES s.r.l.</owners>
-    <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <projectUrl>https://github.com/masesgroup/JNet/</projectUrl>
-    <repository type="git" url="https://github.com/masesgroup/JNet/" />
-    <description>JNetReflector - JNet class reflection utility command line interface</description>
-    <releaseNotes>https://github.com/masesgroup/JNet/releases</releaseNotes>
-    <copyright>Copyright ©  MASES s.r.l. 2025</copyright>
-    <license type="file">LICENSE</license>
-    <icon>JCOB128x128.png</icon>
-    <tags>jnet cli reflection utility dotnet clr netcore net8 java jvm</tags>
-    <packageTypes>
-    <packageType name="DotnetTool" />
-    </packageTypes>
-    <readme>usageReflector.md</readme>
-  </metadata>
+	<metadata>
+		<id>MASES.JNetReflector</id>
+		<version>2.5.13</version>
+		<title>JNetReflector - JNet class reflection utility command line interface</title>
+		<authors>MASES s.r.l.</authors>
+		<owners>MASES s.r.l.</owners>
+		<requireLicenseAcceptance>true</requireLicenseAcceptance>
+		<projectUrl>https://github.com/masesgroup/JNet/</projectUrl>
+		<repository type="git" url="https://github.com/masesgroup/JNet/" />
+		<description>JNetReflector - JNet class reflection utility command line interface</description>
+		<releaseNotes>https://github.com/masesgroup/JNet/releases</releaseNotes>
+		<copyright>Copyright ©  MASES s.r.l. 2025</copyright>
+		<license type="file">LICENSE</license>
+		<icon>JCOB128x128.png</icon>
+		<tags>jnet cli reflection utility dotnet clr netcore net8 java jvm</tags>
+		<packageTypes>
+			<packageType name="DotnetTool" />
+		</packageTypes>
+		<readme>usageReflector.md</readme>
+	</metadata>
 	<files>
 		<file src="..\..\..\LICENSE" target="LICENSE" />
 		<file src="..\Common\JCOB128x128.png" target="" />


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Corrected indentation in JNetCLI.nuspec and JNetReflector.nuspec for consistency. Removed the <PackageType>DotnetTool</PackageType> property from JNetCLICore.csproj, as it is wrong specification.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fix #636
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
