### PR TITLE
Adds `Java.Lang.Record` class 

### DIFF
--- a/src/net/JNet/Developed/Java/Lang/Record.cs
+++ b/src/net/JNet/Developed/Java/Lang/Record.cs
@@ -1,0 +1,35 @@
+﻿/*
+*  Copyright (c) 2022-2026 MASES s.r.l.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*  Refer to LICENSE for more information.
+*/
+
+using MASES.JCOBridge.C2JBridge;
+
+namespace Java.Lang
+{
+    /// <summary>
+    /// .NET implementations of <see href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Record.html"/>
+    /// </summary>
+    public class Record : JVMBridgeBase<Record>
+    {
+        /// <inheritdoc/>
+        public Record() { }
+        /// <inheritdoc/>
+        public Record(IJVMBridgeBaseInitializer initializer) : base(initializer) { }
+        /// <inheritdoc />
+        public override string BridgeClassName => "java.lang.Record";
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds `Java.Lang.Record` class can be used from code generated from JNetReflector without explicit removal of java.lang.Record from usable classes
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
close #721 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
