### PR TITLE
Add listener dispose handlers

### DIFF
--- a/src/net/JNet/Specific/JNetEventResult.cs
+++ b/src/net/JNet/Specific/JNetEventResult.cs
@@ -55,7 +55,7 @@ namespace MASES.JNet.Specific
         /// <summary>
         /// The <see cref="object"/> to be returned to the JVM side
         /// </summary>
-        public object ReturnData { get => IExecute("getReturnData"); set => IExecute("setReturnData", value); }
+        public object ReturnData { get => IExecute("getReturnData"); } // disabled since JVM side raise an exception in any case set => IExecute("setReturnData", value); }
         /// <summary>
         /// Helper function to set both <see cref="HasOverride"/> and <see cref="ReturnData"/>
         /// </summary>

--- a/src/net/JNetReflector/InternalMethods.cs
+++ b/src/net/JNetReflector/InternalMethods.cs
@@ -2020,6 +2020,7 @@ namespace MASES.JNet.Reflector
                         template = Template.GetTemplate(Template.SingleMethodTemplate);
                         singleMethod = template.Replace(AllPackageClasses.ClassStub.MethodStub.DECORATION, jDecoration.ToString())
                                                .Replace(AllPackageClasses.ClassStub.MethodStub.LISTENER_HANDLER_EXECUTION, listenerHandlerType)
+                                               .Replace(AllPackageClasses.ClassStub.MethodStub.LISTENER_DISPOSE_HANDLER, returnType == "void" ? string.Empty : AllPackageClasses.ClassStub.MethodStub.LISTENER_DISPOSE_HANDLER_FORMAT)
                                                .Replace(AllPackageClasses.ClassStub.MethodStub.LISTENER_HANDLER_NAME, baseHandlerName)
                                                .Replace(AllPackageClasses.ClassStub.MethodStub.MODIFIER, modifier)
                                                .Replace(AllPackageClasses.ClassStub.MethodStub.RETURNTYPE, returnType)
@@ -2049,6 +2050,7 @@ namespace MASES.JNet.Reflector
                         template = Template.GetTemplate(Template.SingleMethodTemplate);
                         singleMethod = template.Replace(AllPackageClasses.ClassStub.MethodStub.DECORATION, jDecoration.ToString())
                                                .Replace(AllPackageClasses.ClassStub.MethodStub.LISTENER_HANDLER_EXECUTION, listenerHandlerType)
+                                               .Replace(AllPackageClasses.ClassStub.MethodStub.LISTENER_DISPOSE_HANDLER, returnType == "void" ? string.Empty : AllPackageClasses.ClassStub.MethodStub.LISTENER_DISPOSE_HANDLER_FORMAT)
                                                .Replace(AllPackageClasses.ClassStub.MethodStub.LISTENER_HANDLER_NAME, baseHandlerName)
                                                .Replace(AllPackageClasses.ClassStub.MethodStub.MODIFIER, modifier)
                                                .Replace(AllPackageClasses.ClassStub.MethodStub.RETURNTYPE, returnType)
@@ -2078,6 +2080,7 @@ namespace MASES.JNet.Reflector
                         template = Template.GetTemplate(Template.SingleMethodTemplate);
                         singleMethod = template.Replace(AllPackageClasses.ClassStub.MethodStub.DECORATION, jDecoration.ToString())
                                                .Replace(AllPackageClasses.ClassStub.MethodStub.LISTENER_HANDLER_EXECUTION, listenerHandlerType)
+                                               .Replace(AllPackageClasses.ClassStub.MethodStub.LISTENER_DISPOSE_HANDLER, returnType == "void" ? string.Empty : AllPackageClasses.ClassStub.MethodStub.LISTENER_DISPOSE_HANDLER_FORMAT)
                                                .Replace(AllPackageClasses.ClassStub.MethodStub.LISTENER_HANDLER_NAME, baseHandlerName)
                                                .Replace(AllPackageClasses.ClassStub.MethodStub.MODIFIER, modifier)
                                                .Replace(AllPackageClasses.ClassStub.MethodStub.RETURNTYPE, returnType)
@@ -2149,6 +2152,7 @@ namespace MASES.JNet.Reflector
                 {
                     singleMethod = template.Replace(AllPackageClasses.ClassStub.MethodStub.DECORATION, jDecoration.ToString())
                                            .Replace(AllPackageClasses.ClassStub.MethodStub.LISTENER_HANDLER_EXECUTION, listenerHandlerType)
+                                           .Replace(AllPackageClasses.ClassStub.MethodStub.LISTENER_DISPOSE_HANDLER, returnType == "void" ? string.Empty : AllPackageClasses.ClassStub.MethodStub.LISTENER_DISPOSE_HANDLER_FORMAT)
                                            .Replace(AllPackageClasses.ClassStub.MethodStub.LISTENER_HANDLER_NAME, baseHandlerName)
                                            .Replace(AllPackageClasses.ClassStub.MethodStub.MODIFIER, modifier)
                                            .Replace(AllPackageClasses.ClassStub.MethodStub.RETURNTYPE, returnType)
@@ -2178,6 +2182,7 @@ namespace MASES.JNet.Reflector
 
                     singleMethod = template.Replace(AllPackageClasses.ClassStub.MethodStub.DECORATION, jDecoration.ToString())
                                            .Replace(AllPackageClasses.ClassStub.MethodStub.LISTENER_HANDLER_EXECUTION, listenerHandlerType)
+                                           .Replace(AllPackageClasses.ClassStub.MethodStub.LISTENER_DISPOSE_HANDLER, returnType == "void" ? string.Empty : AllPackageClasses.ClassStub.MethodStub.LISTENER_DISPOSE_HANDLER_FORMAT)
                                            .Replace(AllPackageClasses.ClassStub.MethodStub.LISTENER_HANDLER_NAME, baseHandlerName)
                                            .Replace(AllPackageClasses.ClassStub.MethodStub.MODIFIER, modifier)
                                            .Replace(AllPackageClasses.ClassStub.MethodStub.RETURNTYPE, returnType)

--- a/src/net/JNetReflector/Templates/AllPackageClassesStubClass.template
+++ b/src/net/JNetReflector/Templates/AllPackageClassesStubClass.template
@@ -3,13 +3,15 @@ ALLPACKAGE_CLASSES_STUB_CLASS_DECORATION_PLACEHOLDER
 public partial class ALLPACKAGE_CLASSES_STUB_CLASS_PLACEHOLDER : ALLPACKAGE_CLASSES_STUB_BASECLASS_PLACEHOLDERALLPACKAGE_CLASSES_STUB_WHERECLAUSES_PLACEHOLDER
 {
     const string _bridgeClassName = "ALLPACKAGE_CLASSES_STUB_JAVACLASS_PLACEHOLDER";
+
     /// <summary>
-    /// Internal constructor: used internally from JCOBridge
+    /// Initializer used internally by JCOBridge. Do not use directly.
     /// </summary>
     [global::System.Obsolete("This public initializer is needed for JCOBridge internal use, other uses can produce unidentible behaviors.")]
     public ALLPACKAGE_CLASSES_STUB_SIMPLECLASS_PLACEHOLDER(IJVMBridgeBaseInitializer initializer) : base(initializer) { }
+
     /// <summary>
-    /// Generic constructor: it is useful for JCOBridge when there is a derived class which needs to pass arguments to the highest JVMBridgeBase class
+    /// Generic constructor used by JCOBridge when a derived class needs to forward arguments to the base JVMBridgeBase class.
     /// </summary>
     public ALLPACKAGE_CLASSES_STUB_SIMPLECLASS_PLACEHOLDER(params object[] args) : base(args) { }
 

--- a/src/net/JNetReflector/Templates/AllPackageClassesStubClassInterfaceOrAbstract.template
+++ b/src/net/JNetReflector/Templates/AllPackageClassesStubClassInterfaceOrAbstract.template
@@ -3,14 +3,20 @@ ALLPACKAGE_CLASSES_STUB_CLASS_DECORATION_PLACEHOLDER
 public partial class ALLPACKAGE_CLASSES_STUB_CLASS_PLACEHOLDER : ALLPACKAGE_CLASSES_STUB_BASECLASS_PLACEHOLDERALLPACKAGE_CLASSES_STUB_WHERECLAUSES_PLACEHOLDER
 {
     const string _bridgeClassName = "ALLPACKAGE_CLASSES_STUB_JAVACLASS_PLACEHOLDER";
+
     /// <summary>
-    /// Internal constructor: used internally from JCOBridge
+    /// Initializer used internally by JCOBridge. Do not use directly.
     /// </summary>
     [global::System.Obsolete("This public initializer is needed for JCOBridge internal use, other uses can produce unidentible behaviors.")]
     public ALLPACKAGE_CLASSES_STUB_SIMPLECLASS_PLACEHOLDER(IJVMBridgeBaseInitializer initializer) : base(initializer) { }
+
     /// <summary>
-    /// Generic constructor: it is useful for JCOBridge when there is a derived class which needs to pass arguments to the highest JVMBridgeBase class
+    /// Generic constructor used by JCOBridge when a derived class needs to forward arguments to the base JVMBridgeBase class.
     /// </summary>
+    /// <remarks>
+    /// <see cref="ALLPACKAGE_CLASSES_STUB_SIMPLECLASS_PLACEHOLDER"/> represents a JVM interface or abstract class in .NET.
+    /// Instantiating it directly outside of JCOBridge infrastructure is not supported and may produce undefined behavior.
+    /// </remarks>
     [global::System.Obsolete("ALLPACKAGE_CLASSES_STUB_SIMPLECLASS_PLACEHOLDER class represents, in .NET, an instance of a JVM interface or abstract class. This public initializer is needed for JCOBridge internal use, other uses can produce unidentible behaviors.")]
     public ALLPACKAGE_CLASSES_STUB_SIMPLECLASS_PLACEHOLDER(params object[] args) : base(args) { }
 

--- a/src/net/JNetReflector/Templates/AllPackageClassesStubClassListener.template
+++ b/src/net/JNetReflector/Templates/AllPackageClassesStubClassListener.template
@@ -3,16 +3,17 @@ ALLPACKAGE_CLASSES_STUB_CLASS_DECORATION_PLACEHOLDER
 public partial class ALLPACKAGE_CLASSES_STUB_CLASS_PLACEHOLDER : ALLPACKAGE_CLASSES_STUB_BASECLASS_PLACEHOLDER
 {
     /// <summary>
-    /// Internal constructor: used internally from JCOBridge
+    /// Initializer used internally by JCOBridge. Do not use directly.
     /// </summary>
     [global::System.Obsolete("This public initializer is needed for JCOBridge internal use, other uses can produce unidentible behaviors.")]
-    public ALLPACKAGE_CLASSES_STUB_SIMPLECLASS_PLACEHOLDER(IJVMBridgeBaseInitializer initializer) : base(initializer) 
+    public ALLPACKAGE_CLASSES_STUB_SIMPLECLASS_PLACEHOLDER(IJVMBridgeBaseInitializer initializer) : base(initializer)
     {
-        var listenerRuntimeType = GetType(); 
+        var listenerRuntimeType = GetType();
         _hasALLPACKAGE_CLASSES_STUB_SIMPLECLASS_PLACEHOLDERSecondGate = MASES.JNet.Specific.JNetEventResult.GetMethodIsOverridden(listenerRuntimeType, nameof(ListenerShallManageEvent), typeof(int), typeof(object));
     }
+
     /// <summary>
-    /// Generic constructor: it is useful for JCOBridge when there is a derived class which needs to pass arguments to the highest JVMBridgeBase class
+    /// Generic constructor used by JCOBridge when a derived class needs to forward arguments to the base JVMBridgeBase class.
     /// </summary>
     public ALLPACKAGE_CLASSES_STUB_SIMPLECLASS_PLACEHOLDER(params object[] args) : base(args)
     {
@@ -21,12 +22,27 @@ public partial class ALLPACKAGE_CLASSES_STUB_CLASS_PLACEHOLDER : ALLPACKAGE_CLAS
         InitializeHandlers(listenerRuntimeType);
     }
 
+    /// <summary>
+    /// <see langword="true"/> if the user has overridden <see cref="ListenerShallManageEvent(int, object)"/> in a subclass.
+    /// Cached at construction to avoid per-event reflection cost. When <see langword="true"/>, the first gate always
+    /// returns <see langword="true"/> so that the second gate is reached regardless of whether individual event handlers are registered.
+    /// </summary>
     readonly bool _hasALLPACKAGE_CLASSES_STUB_SIMPLECLASS_PLACEHOLDERSecondGate;
+
     /// <inheritdoc/>
+    /// <remarks>
+    /// Evaluated in order:
+    /// <list type="number">
+    /// <item><see cref="ListenerShallManageEventIndex"/> delegate — index-based, no string conversion, lowest overhead.</item>
+    /// <item><see cref="ListenerShallManageEventName"/> delegate — name-based, resolves via <see cref="ConvertListenerEventIndexToEventName"/>.</item>
+    /// <item><see cref="ListenerShallManageEventHandlers"/> — returns <see langword="true"/> if the specific event has a registered delegate or a virtual method override.</item>
+    /// <item><see cref="_hasALLPACKAGE_CLASSES_STUB_SIMPLECLASS_PLACEHOLDERSecondGate"/> — returns <see langword="true"/> if the second gate is overridden, ensuring all events reach it.</item>
+    /// </list>
+    /// </remarks>
     protected override bool ListenerShallManageEvent(int eventIndex)
     {
-        if (ListenerShallManageEventIndex != null) return ListenerShallManageEventIndex(eventIndex); // test first gate base handler with index
-        if (ListenerShallManageEventName != null) return ListenerShallManageEventName(ConvertListenerEventIndexToEventName(eventIndex)); // or test first gate base handler with name
+        if (ListenerShallManageEventIndex != null) return ListenerShallManageEventIndex(eventIndex);
+        if (ListenerShallManageEventName != null) return ListenerShallManageEventName(ConvertListenerEventIndexToEventName(eventIndex));
         if (ListenerShallManageEventHandlers(eventIndex)) return true;
         return _hasALLPACKAGE_CLASSES_STUB_SIMPLECLASS_PLACEHOLDERSecondGate;
     }
@@ -40,28 +56,40 @@ ALLPACKAGE_CLASSES_STUB_LISTENER_CLASS_PLACEHOLDER
 
 #region ALLPACKAGE_CLASSES_STUB_CLASS_DIRECT_PLACEHOLDER declaration
 /// <summary>
-/// Direct override of <see cref="ALLPACKAGE_CLASSES_STUB_SIMPLECLASS_PLACEHOLDER"/> or its generic type if there is one
+/// Concrete CLR representation of <see cref="ALLPACKAGE_CLASSES_STUB_SIMPLECLASS_PLACEHOLDER"/> returned by the JVM.
 /// </summary>
+/// <remarks>
+/// When the JVM returns an instance of this listener type, JCOBridge needs a concrete CLR class to wrap it.
+/// A full listener implementation cannot be used in this scenario because it would require user-provided handler code
+/// that is not available at the point of construction. This class provides a minimal, handler-free wrapper:
+/// <see cref="InitializeHandlers"/> is a no-op, <see cref="ListenerShallManageEvent(int)"/> unconditionally
+/// returns <see langword="false"/> discarding all events immediately, and <see cref="AutoInit"/> is <see langword="false"/>
+/// to prevent automatic JVM-side registration.
+/// <para>Do not use this class directly to register event handlers — use <see cref="ALLPACKAGE_CLASSES_STUB_SIMPLECLASS_PLACEHOLDER"/> instead.</para>
+/// </remarks>
 public partial class ALLPACKAGE_CLASSES_STUB_CLASS_DIRECT_PLACEHOLDER : ALLPACKAGE_CLASSES_STUB_CLASS_PLACEHOLDER
 {
     /// <summary>
-    /// Internal constructor: used internally from JCOBridge
+    /// Initializer used internally by JCOBridge. Do not use directly.
     /// </summary>
     [global::System.Obsolete("This public initializer is needed for JCOBridge internal use, other uses can produce unidentible behaviors.")]
     public ALLPACKAGE_CLASSES_STUB_SIMPLECLASS_PLACEHOLDERDirect(IJVMBridgeBaseInitializer initializer) : base(initializer) { }
+
     /// <summary>
-    /// Generic constructor: it is useful for JCOBridge when there is a derived class which needs to pass arguments to the highest JVMBridgeBase class
+    /// Generic constructor used by JCOBridge when a derived class needs to forward arguments to the base JVMBridgeBase class.
     /// </summary>
     public ALLPACKAGE_CLASSES_STUB_SIMPLECLASS_PLACEHOLDERDirect(params object[] args) : base(args) { }
 
     /// <inheritdoc/>
     public override bool AutoInit => false;
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
+    /// <remarks>No handlers are registered in this direct override — initialization is intentionally skipped.</remarks>
     protected override void InitializeHandlers(global::System.Type _) { }
 
     /// <inheritdoc/>
-    protected override bool ListenerShallManageEvent(int _) { return false; } // early discard since no handlers are registered
+    /// <remarks>Always returns <see langword="false"/> — all events are discarded at the first gate without reading any JVM argument data.</remarks>
+    protected override bool ListenerShallManageEvent(int _) => false;
 
     const string _bridgeClassName = "ALLPACKAGE_CLASSES_STUB_JAVACLASS_DIRECT_PLACEHOLDER";
     private static readonly global::System.Exception _LocalBridgeClazzException = null;

--- a/src/net/JNetReflector/Templates/SingleListenerJavaFile.template
+++ b/src/net/JNetReflector/Templates/SingleListenerJavaFile.template
@@ -9,63 +9,134 @@ package ALLPACKAGE_PACKAGE_PLACEHOLDER;
 public final class ALLPACKAGE_CLASSES_STUB_SIMPLECLASS_PLACEHOLDER ALLPACKAGE_CLASSES_STUB_EXTEND_JAVACLASS_PLACEHOLDERimplements org.mases.jcobridge.IJCListenerALLPACKAGE_CLASSES_STUB_JAVACLASS_PLACEHOLDER {
     final org.mases.jcobridge.JCListener _internalListener;
 
+    /**
+     * Constructs the listener and registers it with the JCOBridge runtime using the provided key.
+     * @param key the registration key used by JCOBridge to identify this listener instance on the CLR side.
+     * @throws org.mases.jcobridge.JCNativeException if the native bridge initialization fails.
+     */
     public ALLPACKAGE_CLASSES_STUB_SIMPLECLASS_PLACEHOLDER(String key) throws org.mases.jcobridge.JCNativeExceptionCONSTRUCTOR_STUB_CONSTRUCTOR_EXTEND_EXCEPTIONS_PLACEHOLDER {
         super();
         _internalListener = new org.mases.jcobridge.JCListener(key);
     }
 
+    /**
+     * Releases the resources held by this listener and unregisters it from the JCOBridge runtime.
+     */
     public synchronized void release() {
        _internalListener.release();
     }
 
+    /**
+     * Returns the numeric index associated with the given event name.
+     * The index is used by the CLR side for zero-cost index-based event filtering.
+     * @param eventName the name of the event as registered on the CLR side.
+     * @return the numeric index of the event.
+     */
     public synchronized int getEventIndex(String eventName) {
        return _internalListener.getEventIndex(eventName);
     }
-    
+
+    /**
+     * Raises the named event on the CLR side with no associated data.
+     * @param eventName the name of the event to raise.
+     */
     public synchronized void raiseEvent(String eventName) {
        _internalListener.raiseEvent(eventName);
     }
 
+    /**
+     * Raises the event identified by index on the CLR side with no associated data.
+     * @param eventIndex the numeric index of the event to raise.
+     */
     public synchronized void raiseEvent(int eventIndex) {
        _internalListener.raiseEvent(eventIndex);
     }
-    
+
+    /**
+     * Raises the named event on the CLR side, passing a single data object.
+     * @param eventName the name of the event to raise.
+     * @param e the data object associated with the event.
+     */
     public synchronized void raiseEvent(String eventName, Object e) {
        _internalListener.raiseEvent(eventName, e);
     }
 
+    /**
+     * Raises the event identified by index on the CLR side, passing a single data object.
+     * @param eventIndex the numeric index of the event to raise.
+     * @param e the data object associated with the event.
+     */
     public synchronized void raiseEvent(int eventIndex, Object e) {
        _internalListener.raiseEvent(eventIndex, e);
     }
-    
+
+    /**
+     * Raises the named event on the CLR side, passing a primary data object and additional arguments.
+     * @param eventName the name of the event to raise.
+     * @param e the primary data object associated with the event.
+     * @param objects additional arguments forwarded to the CLR handler.
+     */
     public synchronized void raiseEvent(String eventName, Object e, Object... objects) {
        _internalListener.raiseEvent(eventName, e, objects);
     }
 
+    /**
+     * Raises the event identified by index on the CLR side, passing a primary data object and additional arguments.
+     * @param eventIndex the numeric index of the event to raise.
+     * @param e the primary data object associated with the event.
+     * @param objects additional arguments forwarded to the CLR handler.
+     */
     public synchronized void raiseEvent(int eventIndex, Object e, Object... objects) {
        _internalListener.raiseEvent(eventIndex, e, objects);
     }
-    
+
+    /**
+     * Returns the data object sent by the CLR side for the current event, if any.
+     * @return the event data object, or {@code null} if none was provided.
+     */
     public Object getEventData() {
        return _internalListener.getEventData();
     }
-    
+
+    /**
+     * Returns {@code true} if the current event has additional arguments beyond the primary data object.
+     * @return {@code true} if extra data is available.
+     */
     public boolean hasExtraData() {
        return _internalListener.hasExtraData();
     }
-    
+
+    /**
+     * Returns the number of additional arguments associated with the current event.
+     * @return the length of the extra data array.
+     */
     public int extraDataLength() {
        return _internalListener.extraDataLength();
     }
-    
+
+    /**
+     * Returns the additional arguments associated with the current event.
+     * @return an array of extra data objects, or an empty array if none are present.
+     */
     public Object[] extraData() {
        return _internalListener.extraData();
     }
-    
+
+    /**
+     * Returns the return value set by the CLR handler for the current event.
+     * Used when the JVM interface method has a non-void return type and the CLR side
+     * must supply the value via {@link #setReturnData(Object)}.
+     * @return the return value, or {@code null} if not set.
+     */
     public Object getReturnData() {
        return _internalListener.getReturnData();
     }
-    
+
+    /**
+     * Sets the return value that the JVM interface method will return to its caller.
+     * Must be called by the CLR handler before control returns to the JVM for non-void interface methods.
+     * @param retData the value to return to the JVM caller.
+     */
     public void setReturnData(Object retData) {
        _internalListener.setReturnData(retData);
     }

--- a/src/net/JNetReflector/Templates/SingleListenerMethod.template
+++ b/src/net/JNetReflector/Templates/SingleListenerMethod.template
@@ -2,18 +2,29 @@
 /// <summary>
 /// Handler for METHOD_STUB_METHOD_HELP_PLACEHOLDER
 /// </summary>
-/// <remarks>If <see cref="OnMETHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDER"/> has a value it takes precedence over corresponding class method</remarks>
+/// <remarks>
+/// Assign a delegate to handle the event without subclassing. If both this handler and a virtual method override are present,
+/// the delegate takes precedence. Set to <see langword="null"/> to delegate to the virtual method.
+/// </remarks>
 public METHOD_STUB_LISTENER_EXECUTION_TYPE_PLACEHOLDER OnMETHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDER { get; set; } = null;
 METHOD_STUB_LISTENER_DISPOSE_HANDLER_PLACEHOLDER
+/// <summary>Index assigned by <see cref="AddEventHandler"/> for the <see cref="METHOD_STUB_METHOD_NAME_PLACEHOLDER"/> event. Used for zero-cost index-based filtering in <see cref="ListenerShallManageEvent(int)"/>.</summary>
 int METHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDEREventHandlerIndex = 0;
+
+/// <summary><see langword="true"/> if the user has overridden <see cref="METHOD_STUB_METHOD_NAME_PLACEHOLDER"/> in a subclass. Cached at construction to avoid per-event reflection.</summary>
 bool _hasOverrideMETHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDER;
+
+/// <summary>Returns <see langword="true"/> if this event has an active handler — either a delegate assignment or a virtual method override. Used by <see cref="ListenerShallManageEvent(int)"/> to discard events with no registered handler without reading JVM argument data.</summary>
 [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 bool METHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDEREventOverridden() => _hasOverrideMETHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDER || OnMETHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDER != null;
+
 void METHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDEREventHandler(object sender, CLRListenerEventArgs<CLREventData<MASES.JNet.Specific.JNetEventResult>> data)
 {
-    if (!METHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDEREventOverridden()) // can be omitted however it is a protection against an user override of ListenerShallManageEvent
+    if (!METHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDEREventOverridden()) // guard: no handler registered — return without reading data.
+                                                                          // Normally unreachable if ListenerShallManageEvent filtered correctly,
+                                                                          // but protects against user overrides of ListenerShallManageEvent that bypass the check.
     {
-        // returns immediately without analyze anything, data.EventData.TypedEventData.HasOverride is false by default
+        // data.EventData.TypedEventData.HasOverride is false by default — JVM receives no return value.
         return;
     }
 METHOD_STUB_LISTENER_HANDLER_EXECUTION_PLACEHOLDER

--- a/src/net/JNetReflector/Templates/SingleListenerMethod.template
+++ b/src/net/JNetReflector/Templates/SingleListenerMethod.template
@@ -4,7 +4,7 @@
 /// </summary>
 /// <remarks>If <see cref="OnMETHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDER"/> has a value it takes precedence over corresponding class method</remarks>
 public METHOD_STUB_LISTENER_EXECUTION_TYPE_PLACEHOLDER OnMETHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDER { get; set; } = null;
-
+METHOD_STUB_LISTENER_DISPOSE_HANDLER_PLACEHOLDER
 int METHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDEREventHandlerIndex = 0;
 bool _hasOverrideMETHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDER;
 [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]

--- a/src/net/JNetReflector/Templates/SingleListenerMethod.template
+++ b/src/net/JNetReflector/Templates/SingleListenerMethod.template
@@ -9,7 +9,7 @@
 public METHOD_STUB_LISTENER_EXECUTION_TYPE_PLACEHOLDER OnMETHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDER { get; set; } = null;
 METHOD_STUB_LISTENER_DISPOSE_HANDLER_PLACEHOLDER
 /// <summary>Index assigned by <see cref="AddEventHandler"/> for the <see cref="METHOD_STUB_METHOD_NAME_PLACEHOLDER"/> event. Used for zero-cost index-based filtering in <see cref="ListenerShallManageEvent(int)"/>.</summary>
-int METHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDEREventHandlerIndex = 0;
+int _METHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDEREventHandlerIndex = 0;
 
 /// <summary><see langword="true"/> if the user has overridden <see cref="METHOD_STUB_METHOD_NAME_PLACEHOLDER"/> in a subclass. Cached at construction to avoid per-event reflection.</summary>
 bool _hasOverrideMETHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDER;

--- a/src/net/JNetReflector/Templates/Templates.cs
+++ b/src/net/JNetReflector/Templates/Templates.cs
@@ -213,9 +213,9 @@ namespace MASES.JNet.Reflector.Templates
                 public const string LISTENER_HANDLER_EXECUTION = "METHOD_STUB_LISTENER_HANDLER_EXECUTION_PLACEHOLDER";
                 public const string LISTENER_HANDLER_NAME = "METHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDER";
                 public const string LISTENER_DISPOSE_HANDLER = "METHOD_STUB_LISTENER_DISPOSE_HANDLER_PLACEHOLDER";
-                public static string SINGLE_LISTENER_HANDLER_FORMAT = "    METHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDEREventHandlerIndex = AddEventHandler(\"{0}\", new global::System.EventHandler<CLRListenerEventArgs<CLREventData<MASES.JNet.Specific.JNetEventResult>>>(METHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDEREventHandler));" + Environment.NewLine // removed OnMETHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDER = METHOD_STUB_METHOD_NAME_PLACEHOLDER;";
+                public static string SINGLE_LISTENER_HANDLER_FORMAT = "    _METHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDEREventHandlerIndex = AddEventHandler(\"{0}\", new global::System.EventHandler<CLRListenerEventArgs<CLREventData<MASES.JNet.Specific.JNetEventResult>>>(METHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDEREventHandler));" + Environment.NewLine // removed OnMETHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDER = METHOD_STUB_METHOD_NAME_PLACEHOLDER;";
                                                                     + "    _hasOverrideMETHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDER = MASES.JNet.Specific.JNetEventResult.GetMethodIsOverridden(listenerRuntimeType, nameof(METHOD_STUB_METHOD_NAME_PLACEHOLDER)METHOD_STUB_LISTENER_PARAMETERS_TYPES_PLACEHOLDER);";
-                public const string SINGLE_LISTENER_FIRST_GATE_FORMAT = "    if (eventIndex == METHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDEREventHandlerIndex) return METHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDEREventOverridden();";
+                public const string SINGLE_LISTENER_FIRST_GATE_FORMAT = "    if (eventIndex == _METHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDEREventHandlerIndex) return METHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDEREventOverridden();";
                 public const string EXECUTION_FORMAT = "{0}{1}{2}(\"{3}\"{4}{5});";
                 public const string SINGLE_ARRAY_EXECUTION_FORMAT = "new object[] {{ {0} }}";
                 public const string STATIC_EXECUTION_FORMAT = "{0}{1}{2}(LocalBridgeClazz, \"{3}\"{4}{5});";

--- a/src/net/JNetReflector/Templates/Templates.cs
+++ b/src/net/JNetReflector/Templates/Templates.cs
@@ -212,6 +212,7 @@ namespace MASES.JNet.Reflector.Templates
                 public const string LISTENER_PARAMETERS_TYPES = "METHOD_STUB_LISTENER_PARAMETERS_TYPES_PLACEHOLDER";
                 public const string LISTENER_HANDLER_EXECUTION = "METHOD_STUB_LISTENER_HANDLER_EXECUTION_PLACEHOLDER";
                 public const string LISTENER_HANDLER_NAME = "METHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDER";
+                public const string LISTENER_DISPOSE_HANDLER = "METHOD_STUB_LISTENER_DISPOSE_HANDLER_PLACEHOLDER";
                 public static string SINGLE_LISTENER_HANDLER_FORMAT = "    METHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDEREventHandlerIndex = AddEventHandler(\"{0}\", new global::System.EventHandler<CLRListenerEventArgs<CLREventData<MASES.JNet.Specific.JNetEventResult>>>(METHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDEREventHandler));" + Environment.NewLine // removed OnMETHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDER = METHOD_STUB_METHOD_NAME_PLACEHOLDER;";
                                                                     + "    _hasOverrideMETHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDER = MASES.JNet.Specific.JNetEventResult.GetMethodIsOverridden(listenerRuntimeType, nameof(METHOD_STUB_METHOD_NAME_PLACEHOLDER)METHOD_STUB_LISTENER_PARAMETERS_TYPES_PLACEHOLDER);";
                 public const string SINGLE_LISTENER_FIRST_GATE_FORMAT = "    if (eventIndex == METHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDEREventHandlerIndex) return METHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDEREventOverridden();";
@@ -238,12 +239,17 @@ namespace MASES.JNet.Reflector.Templates
                 public const string INSTANCE_EXECUTE = "IExecute";
                 public const string SIGNATURE_EXECUTE_TRAILER = "WithSignature";
 
+                public static readonly string LISTENER_DISPOSE_HANDLER_FORMAT = "" + Environment.NewLine
+                                                                              + "public Func<METHOD_STUB_RETURN_TYPE_PLACEHOLDER> OnMETHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDERDispose { get; set; } = null;" + Environment.NewLine
+                                                                              + "";
+
                 public static readonly string ACTION_LISTENER_EXECUTION_HANDLER_FORMAT = "    var methodToExecute = (OnMETHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDER != null) ? OnMETHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDER : METHOD_STUB_METHOD_NAME_PLACEHOLDER;" + Environment.NewLine
                                                                                        + "    methodToExecute.Invoke(METHOD_STUB_LISTENER_EXECUTION_PLACEHOLDER);" + Environment.NewLine
                                                                                        + "    data.EventData.TypedEventData.HasOverride = METHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDEREventOverridden();";
                 public static readonly string FUNC_LISTENER_EXECUTION_HANDLER_FORMAT = "    var methodToExecute = (OnMETHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDER != null) ? OnMETHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDER : METHOD_STUB_METHOD_NAME_PLACEHOLDER;" + Environment.NewLine
                                                                                      + "    var executionResult = methodToExecute.Invoke(METHOD_STUB_LISTENER_EXECUTION_PLACEHOLDER);" + Environment.NewLine
-                                                                                     + "    data.EventData.TypedEventData.SetReturnData(METHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDEREventOverridden(), executionResult);";
+                                                                                     + "    data.EventData.TypedEventData.SetReturnData(METHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDEREventOverridden(), executionResult);" + Environment.NewLine
+                                                                                     + "    OnMETHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDERDispose?.Invoke(executionResult);";
 
                 public static readonly string BLOCK_LISTENER_HANDLER_FORMAT = "/// <summary>" + Environment.NewLine
                                                                             + "/// Handlers initializer for <see cref=\"{0}\"/>" + Environment.NewLine

--- a/src/net/JNetReflector/Templates/Templates.cs
+++ b/src/net/JNetReflector/Templates/Templates.cs
@@ -240,7 +240,15 @@ namespace MASES.JNet.Reflector.Templates
                 public const string SIGNATURE_EXECUTE_TRAILER = "WithSignature";
 
                 public static readonly string LISTENER_DISPOSE_HANDLER_FORMAT = "" + Environment.NewLine
-                                                                              + "public Func<METHOD_STUB_RETURN_TYPE_PLACEHOLDER> OnMETHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDERDispose { get; set; } = null;" + Environment.NewLine
+                                                                              + "/// <summary>" + Environment.NewLine
+                                                                              + "/// Optional handler invoked after the event handler returns, to dispose the JVM object returned by this event." + Environment.NewLine
+                                                                              + "/// </summary>" + Environment.NewLine
+                                                                              + "/// <remarks>Set <see cref=\"OnMETHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDERDispose\"/> when the event handler returns a JVM-backed object" + Environment.NewLine
+                                                                              + "/// that is no longer needed after the call. The handler receives the return value and is responsible for calling" + Environment.NewLine
+                                                                              + "/// <see cref=\"IDisposable.Dispose\"/> on it, releasing the underlying JVM global reference immediately" + Environment.NewLine
+                                                                              + "/// instead of waiting for the .NET garbage collector to finalize it." + Environment.NewLine
+                                                                              + "/// If not set, the return value is not disposed automatically.</remarks>" + Environment.NewLine
+                                                                              + "public global::System.Action<METHOD_STUB_RETURN_TYPE_PLACEHOLDER> OnMETHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDERDispose { get; set; } = null;" + Environment.NewLine
                                                                               + "";
 
                 public static readonly string ACTION_LISTENER_EXECUTION_HANDLER_FORMAT = "    var methodToExecute = (OnMETHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDER != null) ? OnMETHOD_STUB_LISTENER_HANDLER_NAME_PLACEHOLDER : METHOD_STUB_METHOD_NAME_PLACEHOLDER;" + Environment.NewLine


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Introduce support for listener dispose handlers and disable the ReturnData setter. Added a LISTENER_DISPOSE_HANDLER placeholder and LISTENER_DISPOSE_HANDLER_FORMAT to Templates, updated SingleListenerMethod.template to emit the dispose placeholder, and updated InternalMethods to inject the dispose handler only for non-void return types. Also append a call to the dispose callback after func listener execution. Disabled the ReturnData setter in JNetEventResult because the JVM raises an exception when setting it.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
