### PR TITLE
Add WithData listener delegates support

### DIFF
--- a/src/net/JNetReflector/Templates/AllPackageClassesStubClassListener.template
+++ b/src/net/JNetReflector/Templates/AllPackageClassesStubClassListener.template
@@ -37,6 +37,8 @@ public partial class ALLPACKAGE_CLASSES_STUB_CLASS_PLACEHOLDER : ALLPACKAGE_CLAS
     /// <item><see cref="ListenerShallManageEventName"/> delegate — name-based, resolves via <see cref="ConvertListenerEventIndexToEventName"/>.</item>
     /// <item><see cref="ListenerShallManageEventHandlers"/> — returns <see langword="true"/> if the specific event has a registered delegate or a virtual method override.</item>
     /// <item><see cref="_hasALLPACKAGE_CLASSES_STUB_SIMPLECLASS_PLACEHOLDERSecondGate"/> — returns <see langword="true"/> if the second gate is overridden, ensuring all events reach it.</item>
+    /// <item><see cref="ListenerShallManageEventIndexWithData"/> delegate — index-based, no string conversion, lowest overhead.</item>
+    /// <item><see cref="ListenerShallManageEventNameWithData"/> delegate — name-based, resolves via <see cref="ConvertListenerEventIndexToEventName"/>.</item>
     /// </list>
     /// </remarks>
     protected override bool ListenerShallManageEvent(int eventIndex)
@@ -44,7 +46,7 @@ public partial class ALLPACKAGE_CLASSES_STUB_CLASS_PLACEHOLDER : ALLPACKAGE_CLAS
         if (ListenerShallManageEventIndex != null) return ListenerShallManageEventIndex(eventIndex);
         if (ListenerShallManageEventName != null) return ListenerShallManageEventName(ConvertListenerEventIndexToEventName(eventIndex));
         if (ListenerShallManageEventHandlers(eventIndex)) return true;
-        return _hasALLPACKAGE_CLASSES_STUB_SIMPLECLASS_PLACEHOLDERSecondGate;
+        return _hasALLPACKAGE_CLASSES_STUB_SIMPLECLASS_PLACEHOLDERSecondGate || ListenerShallManageEventIndexWithData != null || ListenerShallManageEventNameWithData != null;
     }
 
 ALLPACKAGE_CLASSES_STUB_LISTENER_CLASS_PLACEHOLDER

--- a/src/net/JNetReflector/Templates/AllPackageClassesStubClassListener.template
+++ b/src/net/JNetReflector/Templates/AllPackageClassesStubClassListener.template
@@ -37,8 +37,8 @@ public partial class ALLPACKAGE_CLASSES_STUB_CLASS_PLACEHOLDER : ALLPACKAGE_CLAS
     /// <item><see cref="ListenerShallManageEventName"/> delegate — name-based, resolves via <see cref="ConvertListenerEventIndexToEventName"/>.</item>
     /// <item><see cref="ListenerShallManageEventHandlers"/> — returns <see langword="true"/> if the specific event has a registered delegate or a virtual method override.</item>
     /// <item><see cref="_hasALLPACKAGE_CLASSES_STUB_SIMPLECLASS_PLACEHOLDERSecondGate"/> — returns <see langword="true"/> if the second gate is overridden, ensuring all events reach it.</item>
-    /// <item><see cref="ListenerShallManageEventIndexWithData"/> delegate — index-based, no string conversion, lowest overhead.</item>
-    /// <item><see cref="ListenerShallManageEventNameWithData"/> delegate — name-based, resolves via <see cref="ConvertListenerEventIndexToEventName"/>.</item>
+    /// <item><see cref="ListenerShallManageEventIndexWithData"/> delegate with data — index-based, no string conversion, lowest overhead.</item>
+    /// <item><see cref="ListenerShallManageEventNameWithData"/> delegate with data — name-based, resolves via <see cref="ConvertListenerEventIndexToEventName"/>.</item>
     /// </list>
     /// </remarks>
     protected override bool ListenerShallManageEvent(int eventIndex)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Update AllPackageClassesStubClassListener template to document two new delegates (ListenerShallManageEventIndexWithData and ListenerShallManageEventNameWithData) and include them in the ListenerShallManageEvent logic. This ensures index-based (no string conversion) and name-based WithData handlers are recognized alongside existing checks, allowing lower-overhead event handling paths.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
