### PR TITLE
Use BindingFlags and validate GetMethod result

### DIFF
--- a/src/net/JNet/Specific/JNetEventResult.cs
+++ b/src/net/JNet/Specific/JNetEventResult.cs
@@ -19,6 +19,7 @@
 using MASES.JCOBridge.C2JBridge;
 using MASES.JCOBridge.C2JBridge.JVMInterop;
 using System;
+using System.Reflection;
 
 namespace MASES.JNet.Specific
 {
@@ -74,9 +75,19 @@ namespace MASES.JNet.Specific
         /// <returns><see langword="true"/> if <paramref name="methodName"/> has an override from the user</returns>
         public static bool GetMethodIsOverridden(global::System.Type thisType, string methodName, params global::System.Type[] types)
         {
-            var method = thisType.GetMethod(methodName, types);
-            var methodOverridden = method.GetBaseDefinition().DeclaringType != method.DeclaringType;
-            return methodOverridden;
+            var method = thisType.GetMethod(
+                methodName,
+                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.FlattenHierarchy,
+                null,
+                types,
+                null
+            );
+
+            if (method == null)
+            {
+                throw new MissingMethodException($"Method '{methodName}' not found on type '{thisType}'");
+            }
+            return method.GetBaseDefinition().DeclaringType != method.DeclaringType;
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Refine GetMethod lookup in JNetEventResult.GetMethodIsOverridden by specifying BindingFlags (Instance, NonPublic, Public, FlattenHierarchy) and the overload signature. Add a null check that throws MissingMethodException if the method is not found, and return the base-definition comparison as before. This ensures accurate method resolution across inheritance and visibility and provides a clear failure when the method is missing.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
