### PR TITLE
Fix for Potentially dangerous use of non-short-circuit logic

### DIFF
--- a/src/net/JNet/JNetCoreBase.cs
+++ b/src/net/JNet/JNetCoreBase.cs
@@ -451,7 +451,7 @@ namespace MASES.JNet
                 {
                     if (args.Length == 0)
                     {
-                        System.Reflection.MethodInfo method = execType.GetMethods().FirstOrDefault(method => method.Name == "SExecute" & method.GetParameters().Length == 2 & method.IsGenericMethod == false);
+                        System.Reflection.MethodInfo method = execType.GetMethods().FirstOrDefault(method => method.Name == "SExecute" && method.GetParameters().Length == 2 && method.IsGenericMethod == false);
                         if (method != null)
                         {
                             method.Invoke(null, new object[] { "main", new object[] { args } });


### PR DESCRIPTION
Use short-circuit boolean operators in the LINQ predicate.

Best fix (without changing functionality): in `src/net/JNet/JNetCoreBase.cs`, line 454, replace boolean `&` operators with `&&` in the `FirstOrDefault` predicate used to locate `SExecute`. This keeps the same logical condition while ensuring left-to-right short-circuit evaluation.

No new methods/imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._