### PR TITLE
Fix for Dereferenced variable is always null

### DIFF
--- a/src/net/JNetReflector/InternalMethods.cs
+++ b/src/net/JNetReflector/InternalMethods.cs
@@ -406,7 +406,7 @@ namespace MASES.JNet.Reflector
             {
                 if (entry == null)
                 {
-                    ReportTrace(ReflectionTraceLevel.Error, "Class Entry {0} returned a null Class", entry.GenericString);
+                    ReportTrace(ReflectionTraceLevel.Error, "Class Entry is null and returned a null Class");
                     continue;
                 }
 


### PR DESCRIPTION
The fix is to remove the dereference of `entry` when `entry` is null and log a safe placeholder/value instead.

Best fix without changing functionality:
- In `src/net/JNetReflector/InternalMethods.cs`, inside `AnalyzeClasses(...)`, update the null-check block in the `foreach` loop.
- Replace the `ReportTrace` call in the `if (entry == null)` branch so it does not access `entry.GenericString`.
- Keep control flow (`continue`) unchanged.

Concretely, change:
- `ReportTrace(..., "Class Entry {0} returned a null Class", entry.GenericString);`
to something safe like:
- `ReportTrace(..., "Class Entry is null and returned a null Class");`
(or pass a literal placeholder argument if keeping `{0}` formatting).

No new methods/imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._