### PR TITLE
Cache direct buffers and update ToDirectBuffer

### DIFF
--- a/src/net/JNet/Developed/Java/Nio/ByteBuffer.cs
+++ b/src/net/JNet/Developed/Java/Nio/ByteBuffer.cs
@@ -331,7 +331,7 @@ namespace Java.Nio
         {
             // Rewind(); removed to avoid the build of a new ByteBuffer object will be discarded and replace with a more simple invocation
             // still remains the allocation of a returning object that is the copy of the current managed ByteBuffer, the copy will be immediately disposed to avoid GEN1 in GC
-            using (var iJobj = IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject) { }
+            using ((IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject)) { }
             return _directBuffer ?? JVM.GetDirectBuffer<byte>(BridgeInstance);
         }
         /// <inheritdoc/>

--- a/src/net/JNet/Developed/Java/Nio/ByteBuffer.cs
+++ b/src/net/JNet/Developed/Java/Nio/ByteBuffer.cs
@@ -332,7 +332,8 @@ namespace Java.Nio
             // Rewind(); removed to avoid the build of a new ByteBuffer object will be discarded and replace with a more simple invocation
             // still remains the allocation of a returning object that is the copy of the current managed ByteBuffer, the copy will be immediately disposed to avoid GEN1 in GC
             using ((IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject)) { }
-            return _directBuffer ?? JVM.GetDirectBuffer<byte>(BridgeInstance);
+            if (_directBuffer == null) _directBuffer = JVM.GetDirectBuffer<byte>(BridgeInstance);
+            return _directBuffer;
         }
         /// <inheritdoc/>
         protected override void Dispose(bool disposing)

--- a/src/net/JNet/Developed/Java/Nio/ByteBuffer.cs
+++ b/src/net/JNet/Developed/Java/Nio/ByteBuffer.cs
@@ -18,6 +18,7 @@
 
 using Java.Lang;
 using MASES.JCOBridge.C2JBridge;
+using MASES.JCOBridge.C2JBridge.JVMInterop;
 using MASES.JNet;
 using MASES.JNet.Specific.Extensions;
 using Microsoft.IO;
@@ -30,6 +31,8 @@ namespace Java.Nio
 {
     public partial class ByteBuffer
     {
+        #region RecyclableMemoryStream
+
         static readonly ConcurrentDictionary<string, RecyclableMemoryStream> _storer = new();
 
         static readonly object _configurationLock = new object();
@@ -174,7 +177,11 @@ namespace Java.Nio
             return stream;
         }
 
+        #endregion
+
         // can be extended with methods not reflected or not available in Java;
+
+        JCOBridgeDirectBuffer<byte> _directBuffer = null;
 
         #region Operators
 
@@ -322,8 +329,16 @@ namespace Java.Nio
         /// <remarks>The returned <see cref="JCOBridgeDirectBuffer{T}"/> can be used to directly access and manages JVM memory without any memory move</remarks>
         public JCOBridgeDirectBuffer<byte> ToDirectBuffer()
         {
-            Rewind();
-            return JVM.GetDirectBuffer<byte>(BridgeInstance);
+            // Rewind(); removed to avoid the build of a new ByteBuffer object will be discarded and replace with a more simple invocation
+            // still remains the allocation of a returning object that is the copy of the current managed ByteBuffer, the copy will be immediately disposed to avoid GEN1 in GC
+            using (var iJobj = IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject) { }
+            return _directBuffer ?? JVM.GetDirectBuffer<byte>(BridgeInstance);
+        }
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            _directBuffer?.Dispose();
+            base.Dispose(disposing);
         }
 
         #endregion

--- a/src/net/JNet/Developed/Java/Nio/CharBuffer.cs
+++ b/src/net/JNet/Developed/Java/Nio/CharBuffer.cs
@@ -18,6 +18,7 @@
 
 using Java.Lang;
 using MASES.JCOBridge.C2JBridge;
+using MASES.JCOBridge.C2JBridge.JVMInterop;
 using MASES.JNet.Specific.Extensions;
 
 namespace Java.Nio
@@ -25,6 +26,8 @@ namespace Java.Nio
     public partial class CharBuffer
     {
         // can be extended with methods not reflected or not available in Java;
+
+        JCOBridgeDirectBuffer<char> _directBuffer = null;
 
         #region Operators
 
@@ -96,8 +99,16 @@ namespace Java.Nio
         /// <remarks>The returned <see cref="JCOBridgeDirectBuffer{T}"/> can be used to directly access and manages JVM memory without any memory move</remarks>
         public JCOBridgeDirectBuffer<char> ToDirectBuffer()
         {
-            Rewind();
-            return JVM.GetDirectBuffer<char>(BridgeInstance);
+            // Rewind(); removed to avoid the build of a new ByteBuffer object will be discarded and replace with a more simple invocation
+            // still remains the allocation of a returning object that is the copy of the current managed ByteBuffer, the copy will be immediately disposed to avoid GEN1 in GC
+            using (var iJobj = IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject) { }
+            return _directBuffer ?? JVM.GetDirectBuffer<char>(BridgeInstance);
+        }
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            _directBuffer?.Dispose();
+            base.Dispose(disposing);
         }
 
         #endregion

--- a/src/net/JNet/Developed/Java/Nio/CharBuffer.cs
+++ b/src/net/JNet/Developed/Java/Nio/CharBuffer.cs
@@ -101,7 +101,7 @@ namespace Java.Nio
         {
             // Rewind(); removed to avoid the build of a new ByteBuffer object will be discarded and replace with a more simple invocation
             // still remains the allocation of a returning object that is the copy of the current managed ByteBuffer, the copy will be immediately disposed to avoid GEN1 in GC
-            using (var iJobj = IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject) { }
+            using var _ = IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject;
             return _directBuffer ?? JVM.GetDirectBuffer<char>(BridgeInstance);
         }
         /// <inheritdoc/>

--- a/src/net/JNet/Developed/Java/Nio/CharBuffer.cs
+++ b/src/net/JNet/Developed/Java/Nio/CharBuffer.cs
@@ -102,7 +102,8 @@ namespace Java.Nio
             // Rewind(); removed to avoid the build of a new ByteBuffer object will be discarded and replace with a more simple invocation
             // still remains the allocation of a returning object that is the copy of the current managed ByteBuffer, the copy will be immediately disposed to avoid GEN1 in GC
             using var _ = IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject;
-            return _directBuffer ?? JVM.GetDirectBuffer<char>(BridgeInstance);
+            if (_directBuffer == null) _directBuffer = JVM.GetDirectBuffer<char>(BridgeInstance);
+            return _directBuffer;
         }
         /// <inheritdoc/>
         protected override void Dispose(bool disposing)

--- a/src/net/JNet/Developed/Java/Nio/DoubleBuffer.cs
+++ b/src/net/JNet/Developed/Java/Nio/DoubleBuffer.cs
@@ -101,7 +101,7 @@ namespace Java.Nio
         {
             // Rewind(); removed to avoid the build of a new ByteBuffer object will be discarded and replace with a more simple invocation
             // still remains the allocation of a returning object that is the copy of the current managed ByteBuffer, the copy will be immediately disposed to avoid GEN1 in GC
-            using (var iJobj = IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject) { }
+            using var _ = IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject;
             return _directBuffer ?? JVM.GetDirectBuffer<double>(BridgeInstance);
         }
         /// <inheritdoc/>

--- a/src/net/JNet/Developed/Java/Nio/DoubleBuffer.cs
+++ b/src/net/JNet/Developed/Java/Nio/DoubleBuffer.cs
@@ -18,6 +18,7 @@
 
 using Java.Lang;
 using MASES.JCOBridge.C2JBridge;
+using MASES.JCOBridge.C2JBridge.JVMInterop;
 using MASES.JNet.Specific.Extensions;
 
 namespace Java.Nio
@@ -25,6 +26,8 @@ namespace Java.Nio
     public partial class DoubleBuffer
     {
         // can be extended with methods not reflected or not available in Java;
+
+        JCOBridgeDirectBuffer<double> _directBuffer = null;
 
         #region Operators
 
@@ -96,8 +99,16 @@ namespace Java.Nio
         /// <remarks>The returned <see cref="JCOBridgeDirectBuffer{T}"/> can be used to directly access and manages JVM memory without any memory move</remarks>
         public JCOBridgeDirectBuffer<double> ToDirectBuffer()
         {
-            Rewind();
-            return JVM.GetDirectBuffer<double>(BridgeInstance);
+            // Rewind(); removed to avoid the build of a new ByteBuffer object will be discarded and replace with a more simple invocation
+            // still remains the allocation of a returning object that is the copy of the current managed ByteBuffer, the copy will be immediately disposed to avoid GEN1 in GC
+            using (var iJobj = IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject) { }
+            return _directBuffer ?? JVM.GetDirectBuffer<double>(BridgeInstance);
+        }
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            _directBuffer?.Dispose();
+            base.Dispose(disposing);
         }
 
         #endregion

--- a/src/net/JNet/Developed/Java/Nio/DoubleBuffer.cs
+++ b/src/net/JNet/Developed/Java/Nio/DoubleBuffer.cs
@@ -81,7 +81,7 @@ namespace Java.Nio
         /// </param>
         /// <param name="timeToLive">The time to live, expressed in milliseconds, the underlying memory shall remain available; if the time to live expires the pinned memory is retired leaving potentially the JVM under the possibility of an access violation.</param>
         /// <returns>A new instance of <see cref="DoubleBuffer"/></returns>
-        public static DoubleBuffer From(double[] data,bool arrangeCapacity = true, int timeToLive = System.Threading.Timeout.Infinite)
+        public static DoubleBuffer From(double[] data, bool arrangeCapacity = true, int timeToLive = System.Threading.Timeout.Infinite)
         {
             try
             {
@@ -102,7 +102,8 @@ namespace Java.Nio
             // Rewind(); removed to avoid the build of a new ByteBuffer object will be discarded and replace with a more simple invocation
             // still remains the allocation of a returning object that is the copy of the current managed ByteBuffer, the copy will be immediately disposed to avoid GEN1 in GC
             using var _ = IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject;
-            return _directBuffer ?? JVM.GetDirectBuffer<double>(BridgeInstance);
+            if (_directBuffer == null) _directBuffer = JVM.GetDirectBuffer<double>(BridgeInstance);
+            return _directBuffer;
         }
         /// <inheritdoc/>
         protected override void Dispose(bool disposing)

--- a/src/net/JNet/Developed/Java/Nio/FloatBuffer.cs
+++ b/src/net/JNet/Developed/Java/Nio/FloatBuffer.cs
@@ -18,6 +18,7 @@
 
 using Java.Lang;
 using MASES.JCOBridge.C2JBridge;
+using MASES.JCOBridge.C2JBridge.JVMInterop;
 using MASES.JNet.Specific.Extensions;
 
 namespace Java.Nio
@@ -25,6 +26,8 @@ namespace Java.Nio
     public partial class FloatBuffer
     {
         // can be extended with methods not reflected or not available in Java;
+
+        JCOBridgeDirectBuffer<float> _directBuffer = null;
 
         #region Operators
 
@@ -96,8 +99,16 @@ namespace Java.Nio
         /// <remarks>The returned <see cref="JCOBridgeDirectBuffer{T}"/> can be used to directly access and manages JVM memory without any memory move</remarks>
         public JCOBridgeDirectBuffer<float> ToDirectBuffer()
         {
-            Rewind();
-            return JVM.GetDirectBuffer<float>(BridgeInstance);
+            // Rewind(); removed to avoid the build of a new ByteBuffer object will be discarded and replace with a more simple invocation
+            // still remains the allocation of a returning object that is the copy of the current managed ByteBuffer, the copy will be immediately disposed to avoid GEN1 in GC
+            using (var iJobj = IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject) { }
+            return _directBuffer ?? JVM.GetDirectBuffer<float>(BridgeInstance);
+        }
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            _directBuffer?.Dispose();
+            base.Dispose(disposing);
         }
 
         #endregion

--- a/src/net/JNet/Developed/Java/Nio/FloatBuffer.cs
+++ b/src/net/JNet/Developed/Java/Nio/FloatBuffer.cs
@@ -102,7 +102,8 @@ namespace Java.Nio
             // Rewind(); removed to avoid the build of a new ByteBuffer object will be discarded and replace with a more simple invocation
             // still remains the allocation of a returning object that is the copy of the current managed ByteBuffer, the copy will be immediately disposed to avoid GEN1 in GC
             using (IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject) { }
-            return _directBuffer ?? JVM.GetDirectBuffer<float>(BridgeInstance);
+            if (_directBuffer == null) _directBuffer = JVM.GetDirectBuffer<float>(BridgeInstance);
+            return _directBuffer;
         }
         /// <inheritdoc/>
         protected override void Dispose(bool disposing)

--- a/src/net/JNet/Developed/Java/Nio/FloatBuffer.cs
+++ b/src/net/JNet/Developed/Java/Nio/FloatBuffer.cs
@@ -101,7 +101,7 @@ namespace Java.Nio
         {
             // Rewind(); removed to avoid the build of a new ByteBuffer object will be discarded and replace with a more simple invocation
             // still remains the allocation of a returning object that is the copy of the current managed ByteBuffer, the copy will be immediately disposed to avoid GEN1 in GC
-            using (var iJobj = IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject) { }
+            using (IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject) { }
             return _directBuffer ?? JVM.GetDirectBuffer<float>(BridgeInstance);
         }
         /// <inheritdoc/>

--- a/src/net/JNet/Developed/Java/Nio/IntBuffer.cs
+++ b/src/net/JNet/Developed/Java/Nio/IntBuffer.cs
@@ -102,7 +102,8 @@ namespace Java.Nio
             // Rewind(); removed to avoid the build of a new ByteBuffer object will be discarded and replace with a more simple invocation
             // still remains the allocation of a returning object that is the copy of the current managed ByteBuffer, the copy will be immediately disposed to avoid GEN1 in GC
             using var _ = IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject;
-            return _directBuffer ?? JVM.GetDirectBuffer<int>(BridgeInstance);
+            if (_directBuffer == null) _directBuffer = JVM.GetDirectBuffer<int>(BridgeInstance);
+            return _directBuffer;
         }
         /// <inheritdoc/>
         protected override void Dispose(bool disposing)

--- a/src/net/JNet/Developed/Java/Nio/IntBuffer.cs
+++ b/src/net/JNet/Developed/Java/Nio/IntBuffer.cs
@@ -101,7 +101,7 @@ namespace Java.Nio
         {
             // Rewind(); removed to avoid the build of a new ByteBuffer object will be discarded and replace with a more simple invocation
             // still remains the allocation of a returning object that is the copy of the current managed ByteBuffer, the copy will be immediately disposed to avoid GEN1 in GC
-            using (var iJobj = IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject) { }
+            using var _ = IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject;
             return _directBuffer ?? JVM.GetDirectBuffer<int>(BridgeInstance);
         }
         /// <inheritdoc/>

--- a/src/net/JNet/Developed/Java/Nio/IntBuffer.cs
+++ b/src/net/JNet/Developed/Java/Nio/IntBuffer.cs
@@ -18,6 +18,7 @@
 
 using Java.Lang;
 using MASES.JCOBridge.C2JBridge;
+using MASES.JCOBridge.C2JBridge.JVMInterop;
 using MASES.JNet.Specific.Extensions;
 
 namespace Java.Nio
@@ -25,6 +26,8 @@ namespace Java.Nio
     public partial class IntBuffer
     {
         // can be extended with methods not reflected or not available in Java;
+
+        JCOBridgeDirectBuffer<int> _directBuffer = null;
 
         #region Operators
 
@@ -96,8 +99,16 @@ namespace Java.Nio
         /// <remarks>The returned <see cref="JCOBridgeDirectBuffer{T}"/> can be used to directly access and manages JVM memory without any memory move</remarks>
         public JCOBridgeDirectBuffer<int> ToDirectBuffer()
         {
-            Rewind();
-            return JVM.GetDirectBuffer<int>(BridgeInstance);
+            // Rewind(); removed to avoid the build of a new ByteBuffer object will be discarded and replace with a more simple invocation
+            // still remains the allocation of a returning object that is the copy of the current managed ByteBuffer, the copy will be immediately disposed to avoid GEN1 in GC
+            using (var iJobj = IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject) { }
+            return _directBuffer ?? JVM.GetDirectBuffer<int>(BridgeInstance);
+        }
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            _directBuffer?.Dispose();
+            base.Dispose(disposing);
         }
 
         #endregion

--- a/src/net/JNet/Developed/Java/Nio/LongBuffer.cs
+++ b/src/net/JNet/Developed/Java/Nio/LongBuffer.cs
@@ -102,7 +102,8 @@ namespace Java.Nio
             // Rewind(); removed to avoid the build of a new ByteBuffer object will be discarded and replace with a more simple invocation
             // still remains the allocation of a returning object that is the copy of the current managed ByteBuffer, the copy will be immediately disposed to avoid GEN1 in GC
             using (IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject) { }
-            return _directBuffer ?? JVM.GetDirectBuffer<long>(BridgeInstance);
+            if (_directBuffer == null) _directBuffer = JVM.GetDirectBuffer<long>(BridgeInstance);
+            return _directBuffer;
         }
         /// <inheritdoc/>
         protected override void Dispose(bool disposing)

--- a/src/net/JNet/Developed/Java/Nio/LongBuffer.cs
+++ b/src/net/JNet/Developed/Java/Nio/LongBuffer.cs
@@ -101,7 +101,7 @@ namespace Java.Nio
         {
             // Rewind(); removed to avoid the build of a new ByteBuffer object will be discarded and replace with a more simple invocation
             // still remains the allocation of a returning object that is the copy of the current managed ByteBuffer, the copy will be immediately disposed to avoid GEN1 in GC
-            using (var iJobj = IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject) { }
+            using (IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject) { }
             return _directBuffer ?? JVM.GetDirectBuffer<long>(BridgeInstance);
         }
         /// <inheritdoc/>

--- a/src/net/JNet/Developed/Java/Nio/LongBuffer.cs
+++ b/src/net/JNet/Developed/Java/Nio/LongBuffer.cs
@@ -18,6 +18,7 @@
 
 using Java.Lang;
 using MASES.JCOBridge.C2JBridge;
+using MASES.JCOBridge.C2JBridge.JVMInterop;
 using MASES.JNet.Specific.Extensions;
 
 namespace Java.Nio
@@ -25,6 +26,8 @@ namespace Java.Nio
     public partial class LongBuffer
     {
         // can be extended with methods not reflected or not available in Java;
+
+        JCOBridgeDirectBuffer<long> _directBuffer = null;
 
         #region Operators
 
@@ -96,8 +99,16 @@ namespace Java.Nio
         /// <remarks>The returned <see cref="JCOBridgeDirectBuffer{T}"/> can be used to directly access and manages JVM memory without any memory move</remarks>
         public JCOBridgeDirectBuffer<long> ToDirectBuffer()
         {
-            Rewind();
-            return JVM.GetDirectBuffer<long>(BridgeInstance);
+            // Rewind(); removed to avoid the build of a new ByteBuffer object will be discarded and replace with a more simple invocation
+            // still remains the allocation of a returning object that is the copy of the current managed ByteBuffer, the copy will be immediately disposed to avoid GEN1 in GC
+            using (var iJobj = IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject) { }
+            return _directBuffer ?? JVM.GetDirectBuffer<long>(BridgeInstance);
+        }
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            _directBuffer?.Dispose();
+            base.Dispose(disposing);
         }
 
         #endregion

--- a/src/net/JNet/Developed/Java/Nio/ShortBuffer.cs
+++ b/src/net/JNet/Developed/Java/Nio/ShortBuffer.cs
@@ -18,6 +18,7 @@
 
 using Java.Lang;
 using MASES.JCOBridge.C2JBridge;
+using MASES.JCOBridge.C2JBridge.JVMInterop;
 using MASES.JNet.Specific.Extensions;
 
 namespace Java.Nio
@@ -25,6 +26,8 @@ namespace Java.Nio
     public partial class ShortBuffer
     {
         // can be extended with methods not reflected or not available in Java;
+
+        JCOBridgeDirectBuffer<short> _directBuffer = null;
 
         #region Operators
 
@@ -96,8 +99,16 @@ namespace Java.Nio
         /// <remarks>The returned <see cref="JCOBridgeDirectBuffer{T}"/> can be used to directly access and manages JVM memory without any memory move</remarks>
         public JCOBridgeDirectBuffer<short> ToDirectBuffer()
         {
-            Rewind();
-            return JVM.GetDirectBuffer<short>(BridgeInstance);
+            // Rewind(); removed to avoid the build of a new ByteBuffer object will be discarded and replace with a more simple invocation
+            // still remains the allocation of a returning object that is the copy of the current managed ByteBuffer, the copy will be immediately disposed to avoid GEN1 in GC
+            using (var iJobj = IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject) { }
+            return _directBuffer ?? JVM.GetDirectBuffer<short>(BridgeInstance);
+        }
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            _directBuffer?.Dispose();
+            base.Dispose(disposing);
         }
 
         #endregion

--- a/src/net/JNet/Developed/Java/Nio/ShortBuffer.cs
+++ b/src/net/JNet/Developed/Java/Nio/ShortBuffer.cs
@@ -101,7 +101,7 @@ namespace Java.Nio
         {
             // Rewind(); removed to avoid the build of a new ByteBuffer object will be discarded and replace with a more simple invocation
             // still remains the allocation of a returning object that is the copy of the current managed ByteBuffer, the copy will be immediately disposed to avoid GEN1 in GC
-            using (var iJobj = IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject) { }
+            using var _ = IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject;
             return _directBuffer ?? JVM.GetDirectBuffer<short>(BridgeInstance);
         }
         /// <inheritdoc/>

--- a/src/net/JNet/Developed/Java/Nio/ShortBuffer.cs
+++ b/src/net/JNet/Developed/Java/Nio/ShortBuffer.cs
@@ -102,7 +102,8 @@ namespace Java.Nio
             // Rewind(); removed to avoid the build of a new ByteBuffer object will be discarded and replace with a more simple invocation
             // still remains the allocation of a returning object that is the copy of the current managed ByteBuffer, the copy will be immediately disposed to avoid GEN1 in GC
             using var _ = IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject;
-            return _directBuffer ?? JVM.GetDirectBuffer<short>(BridgeInstance);
+            if (_directBuffer == null) _directBuffer = JVM.GetDirectBuffer<short>(BridgeInstance);
+            return _directBuffer;
         }
         /// <inheritdoc/>
         protected override void Dispose(bool disposing)

--- a/src/net/JNet/JNet.csproj
+++ b/src/net/JNet/JNet.csproj
@@ -50,7 +50,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="MASES.CLIParser" Version="3.2.1" />
-		<PackageReference Include="MASES.JCOBridge" Version="2.6.9-rc.12">
+		<PackageReference Include="MASES.JCOBridge" Version="2.6.9-rc.13">
 			<IncludeAssets>All</IncludeAssets>
 			<PrivateAssets>None</PrivateAssets>
 		</PackageReference>

--- a/src/net/JNet/JNet.csproj
+++ b/src/net/JNet/JNet.csproj
@@ -50,7 +50,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="MASES.CLIParser" Version="3.2.1" />
-		<PackageReference Include="MASES.JCOBridge" Version="2.6.9-rc.13">
+		<PackageReference Include="MASES.JCOBridge" Version="2.6.9-rc.14">
 			<IncludeAssets>All</IncludeAssets>
 			<PrivateAssets>None</PrivateAssets>
 		</PackageReference>

--- a/src/net/JNetReflector/JNetReflector.csproj
+++ b/src/net/JNetReflector/JNetReflector.csproj
@@ -116,7 +116,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="MASES.CLIParser" Version="3.2.1" />
-		<PackageReference Include="MASES.JCOBridge" Version="2.6.9-rc.12">
+		<PackageReference Include="MASES.JCOBridge" Version="2.6.9-rc.13">
 			<IncludeAssets>All</IncludeAssets>
 			<PrivateAssets>None</PrivateAssets>
 		</PackageReference>

--- a/src/net/JNetReflector/JNetReflector.csproj
+++ b/src/net/JNetReflector/JNetReflector.csproj
@@ -116,7 +116,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="MASES.CLIParser" Version="3.2.1" />
-		<PackageReference Include="MASES.JCOBridge" Version="2.6.9-rc.13">
+		<PackageReference Include="MASES.JCOBridge" Version="2.6.9-rc.14">
 			<IncludeAssets>All</IncludeAssets>
 			<PrivateAssets>None</PrivateAssets>
 		</PackageReference>

--- a/tests/net/JNetByteBufferTest/Program.cs
+++ b/tests/net/JNetByteBufferTest/Program.cs
@@ -366,7 +366,7 @@ namespace MASES.JNetByteBufferTest
                 Stopwatch watcher2 = Stopwatch.StartNew();
                 for (i = 0; i < requestedIterations; i++)
                 {
-                    var res = jClass.Invoke<ByteBuffer>("getByteBuffer");
+                    using var res = jClass.Invoke<ByteBuffer>("getByteBuffer");
                     var array = res.ToArray();
                     if (array.Length != length) { throw new System.Exception(); }
                 }
@@ -380,7 +380,7 @@ namespace MASES.JNetByteBufferTest
                 Stopwatch watcher3 = Stopwatch.StartNew();
                 for (i = 0; i < requestedIterations; i++)
                 {
-                    var res = jClass.Invoke<ByteBuffer>("getByteBuffer");
+                    using var res = jClass.Invoke<ByteBuffer>("getByteBuffer");
                     res.ToArray(ref bytes, false);
                     if (bytes.Length != length) { throw new System.Exception(); }
                 }
@@ -396,7 +396,7 @@ namespace MASES.JNetByteBufferTest
                 Stopwatch watcher4 = Stopwatch.StartNew();
                 for (i = 0; i < requestedIterations; i++)
                 {
-                    var res = jClass.Invoke<ByteBuffer>("getByteBuffer");
+                    using var res = jClass.Invoke<ByteBuffer>("getByteBuffer");
                     res.ToDirectBuffer().CopyTo(handle.AddrOfPinnedObject(), bytes.Length, 0, bytes.Length);
                     if (bytes.Length != length) { throw new System.Exception(); }
                 }
@@ -410,7 +410,7 @@ namespace MASES.JNetByteBufferTest
                 Stopwatch watcher5 = Stopwatch.StartNew();
                 for (i = 0; i < requestedIterations; i++)
                 {
-                    var res = jClass.Invoke<ByteBuffer>("getByteBuffer");
+                    using var res = jClass.Invoke<ByteBuffer>("getByteBuffer");
                     if (res.Remaining() != length) { throw new System.Exception(); }
                 }
                 watcher5.Stop();
@@ -547,7 +547,8 @@ namespace MASES.JNetByteBufferTest
                 System.GC.Collect();
                 Java.Lang.System.Gc();
 
-                var res = jClass.Invoke<ByteBuffer>("getByteBuffer");
+                using var res = jClass.Invoke<ByteBuffer>("getByteBuffer");
+
                 Stopwatch watcher1 = Stopwatch.StartNew();
                 for (iteration = 0; iteration < requestedIterations; iteration++)
                 {
@@ -568,11 +569,10 @@ namespace MASES.JNetByteBufferTest
                 Stopwatch watcher2 = Stopwatch.StartNew();
                 for (iteration = 0; iteration < requestedIterations; iteration++)
                 {
-                    using (JCOBridgeDirectBuffer<byte> db = res.ToDirectBuffer())
-                    {
-                        if (!AreEqualNaive(res.ToStream(), bytes))
-                        { throw new System.Exception(); }
-                    }
+                    JCOBridgeDirectBuffer<byte> db = res.ToDirectBuffer();
+                    using var stream = res.ToStream();
+                    if (!AreEqualNaive(stream, bytes))
+                    { throw new System.Exception(); }
                 }
                 watcher2.Stop();
 
@@ -584,11 +584,10 @@ namespace MASES.JNetByteBufferTest
                 Stopwatch watcher3 = Stopwatch.StartNew();
                 for (iteration = 0; iteration < requestedIterations; iteration++)
                 {
-                    using (JCOBridgeDirectBuffer<byte> db = res.ToDirectBuffer())
-                    {
-                        if (!AreEqualChunked(res.ToStream(), bytes))
-                        { throw new System.Exception(); }
-                    }
+                    JCOBridgeDirectBuffer<byte> db = res.ToDirectBuffer();
+                    using var stream = res.ToStream();
+                    if (!AreEqualChunked(stream, bytes))
+                    { throw new System.Exception(); }
                 }
                 watcher3.Stop();
 
@@ -600,14 +599,12 @@ namespace MASES.JNetByteBufferTest
                 Stopwatch watcher4 = Stopwatch.StartNew();
                 for (iteration = 0; iteration < requestedIterations; iteration++)
                 {
-                    using (JCOBridgeDirectBuffer<byte> db = res.ToDirectBuffer())
-                    {
-                        var span = db.AsSpan();
-                        if (span.Length != length) { throw new System.Exception(); }
+                    JCOBridgeDirectBuffer<byte> db = res.ToDirectBuffer();
+                    var span = db.AsSpan();
+                    if (span.Length != length) { throw new System.Exception(); }
 
-                        if (!span.SequenceEqual(bytes))
-                        { throw new System.Exception(); }
-                    }
+                    if (!span.SequenceEqual(bytes))
+                    { throw new System.Exception(); }
                 }
                 watcher4.Stop();
 

--- a/tests/net/JNetByteBufferTest/Program.cs
+++ b/tests/net/JNetByteBufferTest/Program.cs
@@ -570,7 +570,7 @@ namespace MASES.JNetByteBufferTest
                 for (iteration = 0; iteration < requestedIterations; iteration++)
                 {
                     JCOBridgeDirectBuffer<byte> db = res.ToDirectBuffer();
-                    using var stream = res.ToStream();
+                    using var stream = db.ToStream();
                     if (!AreEqualNaive(stream, bytes))
                     { throw new System.Exception(); }
                 }
@@ -585,7 +585,7 @@ namespace MASES.JNetByteBufferTest
                 for (iteration = 0; iteration < requestedIterations; iteration++)
                 {
                     JCOBridgeDirectBuffer<byte> db = res.ToDirectBuffer();
-                    using var stream = res.ToStream();
+                    using var stream = db.ToStream();
                     if (!AreEqualChunked(stream, bytes))
                     { throw new System.Exception(); }
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add caching and disposal for JCOBridgeDirectBuffer in NIO buffer wrappers and avoid extra object churn when creating direct buffers. Introduce MASES.JCOBridge.C2JBridge.JVMInterop usage, add a _directBuffer field and Dispose override to ByteBuffer/CharBuffer/DoubleBuffer/FloatBuffer/IntBuffer/LongBuffer/ShortBuffer, and replace direct Rewind() calls with a lightweight IExecuteWithSignature invocation. Add a RecyclableMemoryStream region in ByteBuffer. Bump MASES.JCOBridge package to v2.6.9-rc.13 and update tests to use using-disposal for invoked ByteBuffer instances and to stop repeatedly disposing cached direct buffers.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
