### PR TITLE
Dispose JVM return values from function callbacks

### DIFF
--- a/src/net/JNet/Developed/Java/Util/Function/BiFunction.cs
+++ b/src/net/JNet/Developed/Java/Util/Function/BiFunction.cs
@@ -113,6 +113,15 @@ namespace Java.Util.Function
         /// </summary>
         public virtual Func<T, U, TReturn> OnApply { get; set; }
         /// <summary>
+        /// Optional handler invoked after the event handler returns, to dispose the JVM object returned by this event.
+        /// </summary>
+        /// <remarks>Set <see cref="OnApplyDispose"/> when the event handler returns a JVM-backed object
+        /// that is no longer needed after the call. The handler receives the return value and is responsible for calling
+        /// <see cref="IDisposable.Dispose"/> on it, releasing the underlying JVM global reference immediately
+        /// instead of waiting for the .NET garbage collector to finalize it.
+        /// If not set, the return value is not disposed automatically.</remarks>
+        public global::System.Action<TReturn> OnApplyDispose { get; set; } = null;
+        /// <summary>
         /// Initialize a new instance of <see cref="BiFunction{T, U, TReturn}"/>
         /// </summary>
         public BiFunction()
@@ -127,6 +136,7 @@ namespace Java.Util.Function
         {
             var retVal = OnApply(data.EventData.TypedEventData, data.EventData.To<U>(0));
             data.SetReturnValue(retVal);
+            OnApplyDispose?.Invoke(retVal);
         }
         /// <summary>
         /// Executes the Function action in the CLR

--- a/src/net/JNet/Developed/Java/Util/Function/BinaryOperator.cs
+++ b/src/net/JNet/Developed/Java/Util/Function/BinaryOperator.cs
@@ -110,6 +110,15 @@ namespace Java.Util.Function
         /// </summary>
         public virtual Func<T, T, T> OnApply { get; set; }
         /// <summary>
+        /// Optional handler invoked after the event handler returns, to dispose the JVM object returned by this event.
+        /// </summary>
+        /// <remarks>Set <see cref="OnApplyDispose"/> when the event handler returns a JVM-backed object
+        /// that is no longer needed after the call. The handler receives the return value and is responsible for calling
+        /// <see cref="IDisposable.Dispose"/> on it, releasing the underlying JVM global reference immediately
+        /// instead of waiting for the .NET garbage collector to finalize it.
+        /// If not set, the return value is not disposed automatically.</remarks>
+        public global::System.Action<T> OnApplyDispose { get; set; } = null;
+        /// <summary>
         /// Initialize a new instance of <see cref="BinaryOperator{T}"/>
         /// </summary>
         public BinaryOperator()
@@ -124,6 +133,7 @@ namespace Java.Util.Function
         {
             var retVal = OnApply(data.EventData.TypedEventData, data.EventData.To<T>(0));
             data.SetReturnValue(retVal);
+            OnApplyDispose?.Invoke(retVal);
         }
         /// <summary>
         /// Executes the Function action in the CLR

--- a/src/net/JNet/Developed/Java/Util/Function/DoubleFunction.cs
+++ b/src/net/JNet/Developed/Java/Util/Function/DoubleFunction.cs
@@ -98,6 +98,15 @@ namespace Java.Util.Function
         /// </summary>
         public virtual Func<double, TReturn> OnApply { get; set; }
         /// <summary>
+        /// Optional handler invoked after the event handler returns, to dispose the JVM object returned by this event.
+        /// </summary>
+        /// <remarks>Set <see cref="OnApplyDispose"/> when the event handler returns a JVM-backed object
+        /// that is no longer needed after the call. The handler receives the return value and is responsible for calling
+        /// <see cref="IDisposable.Dispose"/> on it, releasing the underlying JVM global reference immediately
+        /// instead of waiting for the .NET garbage collector to finalize it.
+        /// If not set, the return value is not disposed automatically.</remarks>
+        public global::System.Action<TReturn> OnApplyDispose { get; set; } = null;
+        /// <summary>
         /// Initialize a new instance of <see cref="DoubleFunction{TReturn}"/>
         /// </summary>
         public DoubleFunction(Func<double, TReturn> func = null, bool attachEventHandler = true)
@@ -112,6 +121,7 @@ namespace Java.Util.Function
         {
             var retVal = OnApply(data.EventData.TypedEventData);
             data.SetReturnValue(retVal);
+            OnApplyDispose?.Invoke(retVal);
         }
         /// <summary>
         /// Executes the DoubleFunction action in the CLR

--- a/src/net/JNet/Developed/Java/Util/Function/Function.cs
+++ b/src/net/JNet/Developed/Java/Util/Function/Function.cs
@@ -113,6 +113,15 @@ namespace Java.Util.Function
         /// </summary>
         public virtual Func<TObject, TReturn> OnApply { get; set; }
         /// <summary>
+        /// Optional handler invoked after the event handler returns, to dispose the JVM object returned by this event.
+        /// </summary>
+        /// <remarks>Set <see cref="OnApplyDispose"/> when the event handler returns a JVM-backed object
+        /// that is no longer needed after the call. The handler receives the return value and is responsible for calling
+        /// <see cref="IDisposable.Dispose"/> on it, releasing the underlying JVM global reference immediately
+        /// instead of waiting for the .NET garbage collector to finalize it.
+        /// If not set, the return value is not disposed automatically.</remarks>
+        public global::System.Action<TReturn> OnApplyDispose { get; set; } = null;
+        /// <summary>
         /// Initialize a new instance of <see cref="Function{TObject, TReturn}"/>
         /// </summary>
         public Function()
@@ -127,6 +136,7 @@ namespace Java.Util.Function
         {
             var retVal = OnApply(data.EventData.TypedEventData);
             data.SetReturnValue(retVal);
+            OnApplyDispose?.Invoke(retVal);
         }
         /// <summary>
         /// Executes the Function action in the CLR

--- a/src/net/JNet/Developed/Java/Util/Function/IntFunction.cs
+++ b/src/net/JNet/Developed/Java/Util/Function/IntFunction.cs
@@ -92,6 +92,15 @@ namespace Java.Util.Function
         /// </summary>
         public virtual Func<int, TReturn> OnApply { get; set; }
         /// <summary>
+        /// Optional handler invoked after the event handler returns, to dispose the JVM object returned by this event.
+        /// </summary>
+        /// <remarks>Set <see cref="OnApplyDispose"/> when the event handler returns a JVM-backed object
+        /// that is no longer needed after the call. The handler receives the return value and is responsible for calling
+        /// <see cref="IDisposable.Dispose"/> on it, releasing the underlying JVM global reference immediately
+        /// instead of waiting for the .NET garbage collector to finalize it.
+        /// If not set, the return value is not disposed automatically.</remarks>
+        public global::System.Action<TReturn> OnApplyDispose { get; set; } = null;
+        /// <summary>
         /// Initialize a new instance of <see cref="Function{T, TReturn}"/>
         /// </summary>
         public IntFunction()
@@ -106,6 +115,7 @@ namespace Java.Util.Function
         {
             var retVal = OnApply(data.EventData.TypedEventData);
             data.SetReturnValue(retVal);
+            OnApplyDispose?.Invoke(retVal);
         }
         /// <summary>
         /// Executes the Function action in the CLR

--- a/src/net/JNet/Developed/Java/Util/Function/LongFunction.cs
+++ b/src/net/JNet/Developed/Java/Util/Function/LongFunction.cs
@@ -92,6 +92,15 @@ namespace Java.Util.Function
         /// </summary>
         public virtual Func<long, TReturn> OnApply { get; set; }
         /// <summary>
+        /// Optional handler invoked after the event handler returns, to dispose the JVM object returned by this event.
+        /// </summary>
+        /// <remarks>Set <see cref="OnApplyDispose"/> when the event handler returns a JVM-backed object
+        /// that is no longer needed after the call. The handler receives the return value and is responsible for calling
+        /// <see cref="IDisposable.Dispose"/> on it, releasing the underlying JVM global reference immediately
+        /// instead of waiting for the .NET garbage collector to finalize it.
+        /// If not set, the return value is not disposed automatically.</remarks>
+        public global::System.Action<TReturn> OnApplyDispose { get; set; } = null;
+        /// <summary>
         /// Initialize a new instance of <see cref="Function{T, TReturn}"/>
         /// </summary>
         public LongFunction()
@@ -106,6 +115,7 @@ namespace Java.Util.Function
         {
             var retVal = OnApply(data.EventData.TypedEventData);
             data.SetReturnValue(retVal);
+            OnApplyDispose?.Invoke(retVal);
         }
         /// <summary>
         /// Executes the Function action in the CLR

--- a/src/net/JNet/Developed/Java/Util/Function/Supplier.cs
+++ b/src/net/JNet/Developed/Java/Util/Function/Supplier.cs
@@ -91,6 +91,15 @@ namespace Java.Util.Function
         /// </summary>
         public virtual Func<TReturn> OnGet { get; set; }
         /// <summary>
+        /// Optional handler invoked after the event handler returns, to dispose the JVM object returned by this event.
+        /// </summary>
+        /// <remarks>Set <see cref="OnGetDispose"/> when the event handler returns a JVM-backed object
+        /// that is no longer needed after the call. The handler receives the return value and is responsible for calling
+        /// <see cref="IDisposable.Dispose"/> on it, releasing the underlying JVM global reference immediately
+        /// instead of waiting for the .NET garbage collector to finalize it.
+        /// If not set, the return value is not disposed automatically.</remarks>
+        public global::System.Action<TReturn> OnGetDispose { get; set; } = null;
+        /// <summary>
         /// Initialize a new instance of <see cref="Supplier{TReturn}"/>
         /// </summary>
         public Supplier()
@@ -105,6 +114,7 @@ namespace Java.Util.Function
         {
             var retVal = OnGet();
             data.SetReturnValue(retVal);
+            OnGetDispose?.Invoke(retVal);
         }
         /// <summary>
         /// Executes the Supplier action in the CLR

--- a/src/net/JNet/Developed/Java/Util/Function/UnaryOperator.cs
+++ b/src/net/JNet/Developed/Java/Util/Function/UnaryOperator.cs
@@ -116,6 +116,15 @@ namespace Java.Util.Function
         /// </summary>
         public virtual Func<TObject, TObject> OnApply { get; set; }
         /// <summary>
+        /// Optional handler invoked after the event handler returns, to dispose the JVM object returned by this event.
+        /// </summary>
+        /// <remarks>Set <see cref="OnApplyDispose"/> when the event handler returns a JVM-backed object
+        /// that is no longer needed after the call. The handler receives the return value and is responsible for calling
+        /// <see cref="IDisposable.Dispose"/> on it, releasing the underlying JVM global reference immediately
+        /// instead of waiting for the .NET garbage collector to finalize it.
+        /// If not set, the return value is not disposed automatically.</remarks>
+        public global::System.Action<TObject> OnApplyDispose { get; set; } = null;
+        /// <summary>
         /// Initialize a new instance of <see cref="UnaryOperator{TObject}"/>
         /// </summary>
         public UnaryOperator()
@@ -130,6 +139,7 @@ namespace Java.Util.Function
         {
             var retVal = OnApply(data.EventData.TypedEventData);
             data.SetReturnValue(retVal);
+            OnApplyDispose?.Invoke(retVal);
         }
         /// <summary>
         /// Executes the UnaryOperator action in the CLR

--- a/src/net/JNet/Specific/Extensions/JavaUtilExtensions.cs
+++ b/src/net/JNet/Specific/Extensions/JavaUtilExtensions.cs
@@ -118,11 +118,10 @@ namespace MASES.JNet.Specific.Extensions
 #else
                 var jvmData = func != null ? func(item) : TJVMTypeInner.ToJVM(item);
 #endif
-                try
+                using (var disposable = jvmData as IDisposable)
                 {
                     tInstance.Add(jvmData);
                 }
-                finally { (jvmData as IDisposable)?.Dispose(); }
             }
             return tInstance;
         }
@@ -191,16 +190,10 @@ namespace MASES.JNet.Specific.Extensions
             using var keySet = map.KeySet();
             foreach (var key in keySet)
             {
+                using var keyDisposable = key as IDisposable;
                 var value = map.Get(key);
-                try
-                {
-                    tInstance.Add(keyConverter != null ? keyConverter(key) : key.ToCLR(), valueConverter != null ? valueConverter(value) : value.ToCLR());
-                }
-                finally
-                {
-                    (key as IDisposable)?.Dispose();
-                    (value as IDisposable)?.Dispose();
-                }
+                using var valueDisposable = value as IDisposable;
+                tInstance.Add(keyConverter != null ? keyConverter(key) : key.ToCLR(), valueConverter != null ? valueConverter(value) : value.ToCLR());
             }
             return tInstance;
         }
@@ -261,15 +254,9 @@ namespace MASES.JNet.Specific.Extensions
                 var key = keyConverter != null ? keyConverter(item.Key) : TJVMK.ToJVM(item.Key);
                 var value = valueConverter != null ? valueConverter(item.Value) : TJVMV.ToJVM(item.Value);
 #endif
-                try
-                {
-                    tInstance.Put(key, value);
-                }
-                finally
-                {
-                    (key as IDisposable)?.Dispose();
-                    (value as IDisposable)?.Dispose();
-                }
+                using IDisposable keyDisposable = key as IDisposable;
+                using IDisposable valueDisposable = value as IDisposable;
+                tInstance.Put(key, value);
             }
             return tInstance;
         }
@@ -295,14 +282,10 @@ namespace MASES.JNet.Specific.Extensions
             {
                 var key = keyConverter(item.Key);
                 var value = valueConverter(item.Value);
-                try
+                using (var keyDisposable = key as IDisposable)
+                using (var valueDisposable = value as IDisposable)
                 {
                     tInstance.Put(key, value);
-                }
-                finally
-                {
-                    (key as IDisposable)?.Dispose();
-                    (value as IDisposable)?.Dispose();
                 }
             }
             return tInstance;
@@ -346,15 +329,9 @@ namespace MASES.JNet.Specific.Extensions
                 var key = keyConverter != null ? keyConverter(item.Key) : TJVMK.ToJVM(item.Key);
                 var value = valueConverter != null ? valueConverter(item.Value) : TJVMV.ToJVM(item.Value);
 #endif
-                try
-                {
-                    tInstance.Put(key, value);
-                }
-                finally
-                {
-                    (key as IDisposable)?.Dispose();
-                    (value as IDisposable)?.Dispose();
-                }
+                using var keyToDispose = key as IDisposable;
+                using var valueToDispose = value as IDisposable;
+                tInstance.Put(key, value);
             }
             return tInstance;
         }
@@ -380,15 +357,9 @@ namespace MASES.JNet.Specific.Extensions
             {
                 var key = keyConverter(item.Key);
                 var value = valueConverter(item.Value);
-                try
-                {
-                    tInstance.Put(key, value);
-                }
-                finally
-                {
-                    (key as IDisposable)?.Dispose();
-                    (value as IDisposable)?.Dispose();
-                }
+                using var keyToDispose = key as IDisposable;
+                using var valueToDispose = value as IDisposable;
+                tInstance.Put(key, value);
             }
             return tInstance;
         }

--- a/src/net/JNet/Specific/Extensions/JavaUtilExtensions.cs
+++ b/src/net/JNet/Specific/Extensions/JavaUtilExtensions.cs
@@ -255,7 +255,7 @@ namespace MASES.JNet.Specific.Extensions
             foreach (var item in dictionary)
             {
 #if NET462_OR_GREATER || JNET_DOCKER_BUILD_ACTIONS
-                var key = keyConverter(item.Key)
+                var key = keyConverter(item.Key);
                 var value = valueConverter(item.Value);
 #else
                 var key = keyConverter != null ? keyConverter(item.Key) : TJVMK.ToJVM(item.Key);
@@ -340,7 +340,7 @@ namespace MASES.JNet.Specific.Extensions
             foreach (var item in dictionary)
             {
 #if NET462_OR_GREATER || JNET_DOCKER_BUILD_ACTIONS
-                var key = keyConverter(item.Key)
+                var key = keyConverter(item.Key);
                 var value = valueConverter(item.Value);
 #else
                 var key = keyConverter != null ? keyConverter(item.Key) : TJVMK.ToJVM(item.Key);

--- a/src/net/JNet/Specific/Extensions/JavaUtilExtensions.cs
+++ b/src/net/JNet/Specific/Extensions/JavaUtilExtensions.cs
@@ -114,10 +114,15 @@ namespace MASES.JNet.Specific.Extensions
             foreach (var item in set)
             {
 #if NET462_OR_GREATER || JNET_DOCKER_BUILD_ACTIONS
-                tInstance.Add(func(item));
+                var jvmData = func(item);
 #else
-                tInstance.Add(func != null ? func(item) : TJVMTypeInner.ToJVM(item));
+                var jvmData = func != null ? func(item) : TJVMTypeInner.ToJVM(item);
 #endif
+                try
+                {
+                    tInstance.Add(jvmData);
+                }
+                finally { (jvmData as IDisposable)?.Dispose(); }
             }
             return tInstance;
         }
@@ -183,10 +188,19 @@ namespace MASES.JNet.Specific.Extensions
         {
             if (map == null) throw new ArgumentNullException(nameof(map));
             var tInstance = new TDictionaryType();
-            foreach (var key in map.KeySet())
+            using var keySet = map.KeySet();
+            foreach (var key in keySet)
             {
                 var value = map.Get(key);
-                tInstance.Add(keyConverter != null ? keyConverter(key) : key.ToCLR(), valueConverter != null ? valueConverter(value) : value.ToCLR());
+                try
+                {
+                    tInstance.Add(keyConverter != null ? keyConverter(key) : key.ToCLR(), valueConverter != null ? valueConverter(value) : value.ToCLR());
+                }
+                finally
+                {
+                    (key as IDisposable)?.Dispose();
+                    (value as IDisposable)?.Dispose();
+                }
             }
             return tInstance;
         }
@@ -241,10 +255,21 @@ namespace MASES.JNet.Specific.Extensions
             foreach (var item in dictionary)
             {
 #if NET462_OR_GREATER || JNET_DOCKER_BUILD_ACTIONS
-                tInstance.Put(keyConverter(item.Key), valueConverter(item.Value));
+                var key = keyConverter(item.Key)
+                var value = valueConverter(item.Value);
 #else
-                tInstance.Put(keyConverter != null ? keyConverter(item.Key) : TJVMK.ToJVM(item.Key), valueConverter != null ? valueConverter(item.Value) : TJVMV.ToJVM(item.Value));
+                var key = keyConverter != null ? keyConverter(item.Key) : TJVMK.ToJVM(item.Key);
+                var value = valueConverter != null ? valueConverter(item.Value) : TJVMV.ToJVM(item.Value);
 #endif
+                try
+                {
+                    tInstance.Put(key, value);
+                }
+                finally
+                {
+                    (key as IDisposable)?.Dispose();
+                    (value as IDisposable)?.Dispose();
+                }
             }
             return tInstance;
         }
@@ -268,7 +293,17 @@ namespace MASES.JNet.Specific.Extensions
             var tInstance = new HashMap<TJVMK, TJVMV>();
             foreach (var item in dictionary)
             {
-                tInstance.Put(keyConverter(item.Key), valueConverter(item.Value));
+                var key = keyConverter(item.Key);
+                var value = valueConverter(item.Value);
+                try
+                {
+                    tInstance.Put(key, value);
+                }
+                finally
+                {
+                    (key as IDisposable)?.Dispose();
+                    (value as IDisposable)?.Dispose();
+                }
             }
             return tInstance;
         }
@@ -305,10 +340,21 @@ namespace MASES.JNet.Specific.Extensions
             foreach (var item in dictionary)
             {
 #if NET462_OR_GREATER || JNET_DOCKER_BUILD_ACTIONS
-                tInstance.Put(keyConverter(item.Key), valueConverter(item.Value));
+                var key = keyConverter(item.Key)
+                var value = valueConverter(item.Value);
 #else
-                tInstance.Put(keyConverter != null ? keyConverter(item.Key) : TJVMK.ToJVM(item.Key), valueConverter != null ? valueConverter(item.Value) : TJVMV.ToJVM(item.Value));
+                var key = keyConverter != null ? keyConverter(item.Key) : TJVMK.ToJVM(item.Key);
+                var value = valueConverter != null ? valueConverter(item.Value) : TJVMV.ToJVM(item.Value);
 #endif
+                try
+                {
+                    tInstance.Put(key, value);
+                }
+                finally
+                {
+                    (key as IDisposable)?.Dispose();
+                    (value as IDisposable)?.Dispose();
+                }
             }
             return tInstance;
         }
@@ -332,7 +378,17 @@ namespace MASES.JNet.Specific.Extensions
             var tInstance = new Hashtable<TJVMK, TJVMV>();
             foreach (var item in dictionary)
             {
-                tInstance.Put(keyConverter(item.Key), valueConverter(item.Value));
+                var key = keyConverter(item.Key);
+                var value = valueConverter(item.Value);
+                try
+                {
+                    tInstance.Put(key, value);
+                }
+                finally
+                {
+                    (key as IDisposable)?.Dispose();
+                    (value as IDisposable)?.Dispose();
+                }
             }
             return tInstance;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add optional disposal callbacks to Java.Util.Function delegates and ensure temporary JVM objects are disposed in JavaUtilExtensions.

- Introduces OnApplyDispose / OnGetDispose properties (System.Action<T>) to BiFunction, BinaryOperator, DoubleFunction, Function, IntFunction, LongFunction, Supplier, and UnaryOperator. These are invoked after SetReturnValue to allow immediate disposal of JVM-backed return objects (defaults to null, invoked via null-conditional).
- Updates MASES.JNet.Specific.Extensions.JavaUtilExtensions to dispose intermediate JVM objects created during collection/map conversions: uses try/finally to Dispose temporary jvmData, keys and values, and adds using for keySet where appropriate to avoid leaking JVM global references.

This prevents leaking JVM global references by releasing them immediately when CLR-side code no longer needs the returned JVM objects.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
