### PR TITLE
Disable field.IsFinal usage for HPA pooling

### DIFF
--- a/src/net/JNetReflector/InternalMethods.cs
+++ b/src/net/JNetReflector/InternalMethods.cs
@@ -2509,7 +2509,7 @@ namespace MASES.JNet.Reflector
 
                 ReportTrace(ReflectionTraceLevel.Debug, "Preparing field {0}", field.GenericString);
 
-                bool isFinal = field.IsFinal();
+                bool isFinal = false; // disable usage to be compliant with HPA pooling field.IsFinal();
                 string getFunction;
                 string getFormat;
                 string setFormat;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Replace call to field.IsFinal() with a hardcoded false in InternalMethods.cs to avoid using IsFinal during field preparation. This change prevents invoking IsFinal to remain compliant with HPA pooling behavior and avoids related issues when preparing field accessors.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
