### PR TITLE
Add DisposeIfDisposable and replace using

### DIFF
--- a/src/net/JNet/Developed/Java/Nio/ByteBuffer.cs
+++ b/src/net/JNet/Developed/Java/Nio/ByteBuffer.cs
@@ -424,7 +424,7 @@ namespace Java.Nio
             {
                 // Rewind(); removed to avoid the build of a new ByteBuffer object will be discarded and replace with a more simple invocation
                 // still remains the allocation of a returning object that is the copy of the current managed ByteBuffer, the copy will be immediately disposed to avoid GEN1 in GC
-                using var _ = IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject;
+                IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;").DisposeIfDisposable();
             }
             return _directBuffer ??= JVM.GetDirectBuffer<byte>(BridgeInstance);
         }

--- a/src/net/JNet/Developed/Java/Nio/CharBuffer.cs
+++ b/src/net/JNet/Developed/Java/Nio/CharBuffer.cs
@@ -195,7 +195,7 @@ namespace Java.Nio
             {
                 // Rewind(); removed to avoid the build of a new CharBuffer object will be discarded and replace with a more simple invocation
                 // still remains the allocation of a returning object that is the copy of the current managed CharBuffer, the copy will be immediately disposed to avoid GEN1 in GC
-                using var _ = IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject;
+                IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;").DisposeIfDisposable();
             }
             return _directBuffer ??= JVM.GetDirectBuffer<char>(BridgeInstance);
         }

--- a/src/net/JNet/Developed/Java/Nio/DoubleBuffer.cs
+++ b/src/net/JNet/Developed/Java/Nio/DoubleBuffer.cs
@@ -195,7 +195,7 @@ namespace Java.Nio
             {
                 // Rewind(); removed to avoid the build of a new DoubleBuffer object will be discarded and replace with a more simple invocation
                 // still remains the allocation of a returning object that is the copy of the current managed DoubleBuffer, the copy will be immediately disposed to avoid GEN1 in GC
-                using var _ = IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject;
+                IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;").DisposeIfDisposable();
             }
             return _directBuffer ??= JVM.GetDirectBuffer<double>(BridgeInstance);
         }

--- a/src/net/JNet/Developed/Java/Nio/FloatBuffer.cs
+++ b/src/net/JNet/Developed/Java/Nio/FloatBuffer.cs
@@ -196,7 +196,7 @@ namespace Java.Nio
             {
                 // Rewind(); removed to avoid the build of a new FloatBuffer object will be discarded and replace with a more simple invocation
                 // still remains the allocation of a returning object that is the copy of the current managed FloatBuffer, the copy will be immediately disposed to avoid GEN1 in GC
-                using var _ = IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject;
+                IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;").DisposeIfDisposable();
             }
             return _directBuffer ??= JVM.GetDirectBuffer<float>(BridgeInstance);
         }

--- a/src/net/JNet/Developed/Java/Nio/IntBuffer.cs
+++ b/src/net/JNet/Developed/Java/Nio/IntBuffer.cs
@@ -196,7 +196,7 @@ namespace Java.Nio
             {
                 // Rewind(); removed to avoid the build of a new IntBuffer object will be discarded and replace with a more simple invocation
                 // still remains the allocation of a returning object that is the copy of the current managed IntBuffer, the copy will be immediately disposed to avoid GEN1 in GC
-                using var _ = IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject;
+                IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;").DisposeIfDisposable();
             }
             return _directBuffer ??= JVM.GetDirectBuffer<int>(BridgeInstance);
         }

--- a/src/net/JNet/Developed/Java/Nio/LongBuffer.cs
+++ b/src/net/JNet/Developed/Java/Nio/LongBuffer.cs
@@ -196,7 +196,7 @@ namespace Java.Nio
             {
                 // Rewind(); removed to avoid the build of a new LongBuffer object will be discarded and replace with a more simple invocation
                 // still remains the allocation of a returning object that is the copy of the current managed LongBuffer, the copy will be immediately disposed to avoid GEN1 in GC
-                using var _ = IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject;
+                IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;").DisposeIfDisposable();
             }
             return _directBuffer ??= JVM.GetDirectBuffer<long>(BridgeInstance);
         }

--- a/src/net/JNet/Developed/Java/Nio/ShortBuffer.cs
+++ b/src/net/JNet/Developed/Java/Nio/ShortBuffer.cs
@@ -196,7 +196,7 @@ namespace Java.Nio
             {
                 // Rewind(); removed to avoid the build of a new ShortBuffer object will be discarded and replace with a more simple invocation
                 // still remains the allocation of a returning object that is the copy of the current managed ShortBuffer, the copy will be immediately disposed to avoid GEN1 in GC
-                using var _ = IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;") as IJavaObject;
+                IExecuteWithSignature("rewind", "()Ljava/nio/Buffer;").DisposeIfDisposable();
             }
             return _directBuffer ??= JVM.GetDirectBuffer<short>(BridgeInstance);
         }

--- a/src/net/JNet/Specific/Extensions/JNetCoreExtensions.cs
+++ b/src/net/JNet/Specific/Extensions/JNetCoreExtensions.cs
@@ -48,6 +48,14 @@ namespace MASES.JNet.Specific.Extensions
             }
             return varArgs.ToArray();
         }
+        /// <summary>
+        /// Disposes the result of an operation if it is not needed for other purposes
+        /// </summary>
+        /// <param name="obj">The <see cref="object"/> to use for <see cref="IDisposable"/> interface identification</param>
+        public static void DisposeIfDisposable(this object obj)
+        {
+            if (obj is IDisposable disposable) disposable.Dispose();
+        }
 
         /// <summary>
         /// Retrieve the <see cref="Java.Lang.Class{TClass}"/> from the <typeparamref name="TClass"/>

--- a/src/net/JNet/Specific/Extensions/JavaUtilExtensions.cs
+++ b/src/net/JNet/Specific/Extensions/JavaUtilExtensions.cs
@@ -285,7 +285,7 @@ namespace MASES.JNet.Specific.Extensions
 #endif
                 using IDisposable keyDisposable = key as IDisposable;
                 using IDisposable valueDisposable = value as IDisposable;
-                using var _ = tInstance.Put(key, value) as IDisposable;
+                tInstance.Put(key, value).DisposeIfDisposable();
             }
             return tInstance;
         }
@@ -314,7 +314,7 @@ namespace MASES.JNet.Specific.Extensions
                 using (var keyDisposable = key as IDisposable)
                 using (var valueDisposable = value as IDisposable)
                 {
-                    using var _ = tInstance.Put(key, value) as IDisposable;
+                    tInstance.Put(key, value).DisposeIfDisposable();
                 }
             }
             return tInstance;
@@ -360,7 +360,7 @@ namespace MASES.JNet.Specific.Extensions
 #endif
                 using var keyToDispose = key as IDisposable;
                 using var valueToDispose = value as IDisposable;
-                using var _ = tInstance.Put(key, value) as IDisposable;
+                tInstance.Put(key, value).DisposeIfDisposable();
             }
             return tInstance;
         }
@@ -388,7 +388,7 @@ namespace MASES.JNet.Specific.Extensions
                 var value = valueConverter(item.Value);
                 using var keyToDispose = key as IDisposable;
                 using var valueToDispose = value as IDisposable;
-                using var _ = tInstance.Put(key, value) as IDisposable;
+                tInstance.Put(key, value).DisposeIfDisposable();
             }
             return tInstance;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Introduce DisposeIfDisposable(object) extension to dispose objects that implement IDisposable. Replace temporary "using var _ = ... as IDisposable" patterns with .DisposeIfDisposable() calls across Java.Nio buffer classes (ByteBuffer, CharBuffer, DoubleBuffer, FloatBuffer, IntBuffer, LongBuffer, ShortBuffer) and JavaUtilExtensions to avoid allocating disposable temporaries and reduce GC pressure.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
