### PR TITLE
Guard _sync null in DoWorkCycle

### DIFF
--- a/src/net/JNet/Specific/AsyncEnumerable.cs
+++ b/src/net/JNet/Specific/AsyncEnumerable.cs
@@ -59,9 +59,13 @@ namespace MASES.JNet.Specific
         /// <inheritdoc/>
         protected override bool DoWorkCycle()
         {
-            _sync.WaitOne();
-            _sync.Reset();
-            return !_cancellationToken.IsCancellationRequested;
+            if (_sync != null)
+            {
+                _sync.WaitOne();
+                _sync.Reset();
+                return !_cancellationToken.IsCancellationRequested;
+            }
+            return false;
         }
 
         /// <inheritdoc cref="IAsyncEnumerator{T}.Current"/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add a null check for the _sync field in DoWorkCycle to avoid a potential NullReferenceException. If _sync is non-null, the method preserves the previous behavior (WaitOne, Reset, and honor the cancellation token); if _sync is null it now returns false. This change prevents crashes when the sync handle is not initialized.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
