### PR TITLE
Add optional Linux core dump support in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,6 +62,11 @@ on:
         required: false
         default: false
         type: boolean
+      EnableLinuxCoreDump:
+        description: 'Enable Linux process dump'
+        required: false
+        default: false
+        type: boolean
       EnableProcessDump:
         description: 'Enable .NET process dump'
         required: false
@@ -180,6 +185,7 @@ jobs:
       EnableWindowsTests: ${{ inputs.EnableWindowsTests || github.ref_name == 'master' || github.event_name == 'schedule' }}
       EnableMacOSTests: ${{ inputs.EnableMacOSTests || github.event_name == 'schedule' }}
       ForceContinueOnError: ${{ inputs.ForceContinueOnError || false }}
+      EnableLinuxCoreDump: ${{ inputs.EnableLinuxCoreDump || false }}
       EnableProcessDump: ${{ inputs.EnableProcessDump || '0' }}
       ProcessDumpType: ${{ inputs.ProcessDumpType || '3' }}
       EnableVerboseDiagnosticProcessDump: ${{ inputs.EnableVerboseDiagnosticProcessDump || '0' }}

--- a/.github/workflows/build_common.yaml
+++ b/.github/workflows/build_common.yaml
@@ -830,6 +830,21 @@ jobs:
             dotnet ./bin/${{ matrix.framework }}/JNetByteBufferTest.dll $TEST ${{ env.EXTRA_ARGUMENT }}
           done
 
+      - name: Collect systemd coredumps
+        if: always()
+        shell: bash
+        run: |
+          mkdir -p "${{ github.workspace }}/coredumps"
+      
+          echo "=== coredumpctl list ==="
+          coredumpctl list || true
+      
+          echo "=== exporting latest coredump ==="
+          coredumpctl -1 dump > "${{ github.workspace }}/coredumps/latest.core" || true
+      
+          echo "=== coredump files ==="
+          ls -lah "${{ github.workspace }}/coredumps" || true
+
       - name: Collect core dumps
         if: always()
         uses: actions/upload-artifact@v7
@@ -840,6 +855,7 @@ jobs:
             core*
             **/core*
             **/coredump*
+            ${{ github.workspace }}/coredumps/*
 
       - shell: pwsh
         run: Register-PSRepository -Name Local_Nuget_Feed -SourceLocation $env:GITHUB_WORKSPACE\bin -PublishLocation $env:GITHUB_WORKSPACE\bin -InstallationPolicy Trusted

--- a/.github/workflows/build_common.yaml
+++ b/.github/workflows/build_common.yaml
@@ -834,16 +834,15 @@ jobs:
         if: always()
         shell: bash
         run: |
-          mkdir -p "${{ github.workspace }}/coredumps"
+          if coredumpctl -1 info >/dev/null 2>&1; then
+            mkdir -p "${{ github.workspace }}/coredumps"
       
-          echo "=== coredumpctl list ==="
-          coredumpctl list || true
+            coredumpctl -1 info \
+              > "${{ github.workspace }}/coredumps/latest.info.txt"
       
-          echo "=== exporting latest coredump ==="
-          coredumpctl -1 dump > "${{ github.workspace }}/coredumps/latest.core" || true
-      
-          echo "=== coredump files ==="
-          ls -lah "${{ github.workspace }}/coredumps" || true
+            coredumpctl -1 dump \
+              > "${{ github.workspace }}/coredumps/latest.core"
+          fi
 
       - name: Collect core dumps
         if: always()

--- a/.github/workflows/build_common.yaml
+++ b/.github/workflows/build_common.yaml
@@ -62,6 +62,11 @@ on:
         required: false
         default: false
         type: boolean
+      EnableLinuxCoreDump:
+        description: 'Enable Linux process dump'
+        required: false
+        default: false
+        type: boolean
       EnableProcessDump:
         description: 'Enable .NET process dump'
         required: false
@@ -719,6 +724,31 @@ jobs:
         shell: bash
         run: echo "PS_EXTRA_ARGUMENT=${{ env.JAVA_HOME }}" >> $GITHUB_ENV
 
+      - name: Core dump diagnostics
+        if: ${{ inputs.EnableLinuxCoreDump == true }}
+        shell: bash
+        run: |
+          echo "Core limit:"
+          ulimit -c
+      
+          echo "Core pattern:"
+          cat /proc/sys/kernel/core_pattern
+      
+          echo "Core uses pid:"
+          cat /proc/sys/kernel/core_uses_pid
+
+      - name: Enable Linux core dumps
+        if: ${{ inputs.EnableLinuxCoreDump == true }}
+        shell: bash
+        run: |
+          ulimit -c unlimited
+
+          echo "Core pattern:"
+          cat /proc/sys/kernel/core_pattern
+
+          echo "Core size:"
+          ulimit -c
+
       - continue-on-error: ${{ inputs.ForceContinueOnError == true }}
         timeout-minutes: 5
         run: dotnet ./bin/${{ matrix.framework }}/JNetPerformanceTest.dll ${{ env.EXTRA_ARGUMENT }}
@@ -799,6 +829,17 @@ jobs:
             echo "=== Starting $TEST at $(date) ==="
             dotnet ./bin/${{ matrix.framework }}/JNetByteBufferTest.dll $TEST ${{ env.EXTRA_ARGUMENT }}
           done
+
+      - name: Collect core dumps
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coredumps_${{ matrix.os }}_${{ matrix.framework }}_${{ matrix.jdk_vendor }}_${{ matrix.jdk_version }}
+          if-no-files-found: ignore
+          path: |
+            core*
+            **/core*
+            **/coredump*
 
       - shell: pwsh
         run: Register-PSRepository -Name Local_Nuget_Feed -SourceLocation $env:GITHUB_WORKSPACE\bin -PublishLocation $env:GITHUB_WORKSPACE\bin -InstallationPolicy Trusted


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Introduce an EnableLinuxCoreDump workflow input (default: false) in build.yaml and build_common.yaml and wire it into job variables. When enabled, CI will print core-related diagnostics, set ulimit -c unlimited to allow core dumps, and always upload any core* / coredump* files as an artifact for post-mortem debugging. The feature is off by default to avoid extra noise in normal runs.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
